### PR TITLE
Made compatible with TF v1.0 and Python 3.x

### DIFF
--- a/Article Draft.ipynb
+++ b/Article Draft.ipynb
@@ -383,7 +383,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -397,7 +397,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/ops.py
+++ b/ops.py
@@ -3,7 +3,9 @@ logging.basicConfig(format="[%(asctime)s] %(message)s", datefmt="%m-%d %H:%M:%S"
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.ops import rnn_cell
+# from tensorflow.python.ops import rnn_cell
+# tensorflow/contrib/rnn/python/ops/core_rnn_cell.py
+from tensorflow.contrib.rnn.python.ops import core_rnn_cell
 from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.contrib.layers import variance_scaling_initializer
 
@@ -79,7 +81,7 @@ def conv2d(
     activation_fn=None,
     weights_initializer=WEIGHT_INITIALIZER,
     weights_regularizer=None,
-    biases_initializer=tf.zeros_initializer,
+    biases_initializer=tf.zeros_initializer(),
     biases_regularizer=None,
     scope="conv2d"):
   with tf.variable_scope(scope):
@@ -138,7 +140,7 @@ def conv1d(
     activation_fn=None,
     weights_initializer=WEIGHT_INITIALIZER,
     weights_regularizer=None,
-    biases_initializer=tf.zeros_initializer,
+    biases_initializer=tf.zeros_initializer(),
     biases_regularizer=None,
     scope="conv1d"):
   with tf.variable_scope(scope):
@@ -152,7 +154,7 @@ def conv1d(
       tf.float32, weights_initializer, weights_regularizer)
     tf.add_to_collection('conv1d_weights', weights)
 
-    outputs = tf.nn.conv2d(inputs, 
+    outputs = tf.nn.conv2d(inputs,
         weights, [1, stride_h, stride_w, 1], padding=padding, name='outputs')
     tf.add_to_collection('conv1d_outputs', weights)
 
@@ -225,7 +227,7 @@ def diagonal_lstm(inputs, conf, scope='diagonal_lstm'):
 
     tf.add_to_collection('rnn_inputs', rnn_inputs)
 
-    rnn_input_list = [tf.squeeze(rnn_input, squeeze_dims=[1]) 
+    rnn_input_list = [tf.squeeze(rnn_input, squeeze_dims=[1])
         for rnn_input in tf.split(split_dim=1, num_split=width, value=rnn_inputs)]
 
     cell = DiagonalLSTMCell(conf.hidden_dims, height, channel)
@@ -249,7 +251,7 @@ def diagonal_lstm(inputs, conf, scope='diagonal_lstm'):
 
     return outputs
 
-class DiagonalLSTMCell(rnn_cell.RNNCell):
+class DiagonalLSTMCell(core_rnn_cell.RNNCell):
   def __init__(self, hidden_dims, height, channel):
     self._num_unit_shards = 1
     self._forget_bias = 1.
@@ -310,7 +312,7 @@ class DiagonalLSTMCell(rnn_cell.RNNCell):
     new_state = tf.concat(1, [c, h])
     return h, new_state
 
-class RowLSTMCell(rnn_cell.RNNCell):
+class RowLSTMCell(core_rnn_cell.RNNCell):
   def __init__(self, num_units, kernel_shape=[3, 1]):
     self._num_units = num_units
     self._state_size = num_units * 2

--- a/pixelrnn.ipynb
+++ b/pixelrnn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -87,11 +87,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting MNIST-data/train-images-idx3-ubyte.gz\n",
+      "Extracting MNIST-data/train-labels-idx1-ubyte.gz\n",
+      "Extracting MNIST-data/t10k-images-idx3-ubyte.gz\n",
+      "Extracting MNIST-data/t10k-labels-idx1-ubyte.gz\n"
+     ]
+    }
+   ],
    "source": [
     "# TODO add hyperparams to model saving\n",
     "model_dir = setup_model_saving(p.model, p.data, hyperparams)\n",
@@ -110,24 +121,40 @@
     "\n",
     "height, width, channel = 28, 28, 1\n",
     "\n",
-    "train_step_per_epoch = mnist.train.num_examples / p.batch_size\n",
-    "test_step_per_epoch = mnist.test.num_examples / p.batch_size"
+    "train_step_per_epoch = mnist.train.num_examples // p.batch_size\n",
+    "test_step_per_epoch = mnist.test.num_examples // p.batch_size"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup network"
+    "## Set up network"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building CONV0\n",
+      "Building CONV1\n",
+      "Building CONV2\n",
+      "Building CONV3\n",
+      "Building CONV4\n",
+      "Building CONV5\n",
+      "Building CONV6\n",
+      "Building CONV_OUT0\n",
+      "Building CONV_OUT1\n"
+     ]
+    }
+   ],
    "source": [
     "def pixelRNN(height, width, channel, params):\n",
     "    \"\"\"\n",
@@ -145,13 +172,13 @@
     "    \n",
     "    # main reccurent layers\n",
     "    last_hid = conv_inputs\n",
-    "    for idx in xrange(params.recurrent_length):\n",
+    "    for idx in range(params.recurrent_length):\n",
     "        scope = 'CONV%d' % idx\n",
     "        last_hid = conv2d(last_hid, 3, [1, 1], \"B\", scope=scope)\n",
     "        print(\"Building %s\" % scope)\n",
     "\n",
     "    # output reccurent layers\n",
-    "    for idx in xrange(params.out_recurrent_length):\n",
+    "    for idx in range(params.out_recurrent_length):\n",
     "        scope = 'CONV_OUT%d' % idx\n",
     "        last_hid = tf.nn.relu(conv2d(last_hid, params.out_hidden_dims, [1, 1], \"B\", scope=scope))\n",
     "        print(\"Building %s\" % scope)\n",
@@ -159,18 +186,27 @@
     "    conv2d_out_logits = conv2d(last_hid, 1, [1, 1], \"B\", scope='conv2d_out_logits')\n",
     "    output = tf.nn.sigmoid(conv2d_out_logits)\n",
     "    return inputs, output, conv2d_out_logits\n",
+    "\n",
     "inputs, output, conv2d_out_logits = pixelRNN(height, width, channel, p)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building pixel_cnn finished!\n"
+     ]
+    }
+   ],
    "source": [
-    "loss = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(conv2d_out_logits, inputs, name='loss'))\n",
+    "loss = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(logits=conv2d_out_logits, labels=inputs, name='loss'))\n",
     "\n",
     "optimizer = tf.train.RMSPropOptimizer(p.learning_rate)\n",
     "grads_and_vars = optimizer.compute_gradients(loss)\n",
@@ -185,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -197,9 +233,9 @@
     "def generate(sess, height, width, inputs, output):\n",
     "    samples = np.zeros((100, height, width, 1), dtype='float32')\n",
     "\n",
-    "    for i in xrange(height):\n",
-    "        for j in xrange(width):\n",
-    "            for k in xrange(channel):\n",
+    "    for i in range(height):\n",
+    "        for j in range(width):\n",
+    "            for k in range(channel):\n",
     "                next_sample = binarize(predict(sess, samples, inputs, output))\n",
     "                samples[:, i, j, k] = next_sample[:, i, j, k]\n",
     "\n",
@@ -215,93 +251,149 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false,
-    "scrolled": false
+    "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████████████████████▌                     | 1/2 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Start training\n",
+      "Start epoch\n",
+      "Start testing\n",
+      "Start generation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "train l: 0.246, test l: 0.138: 100%|████| 2/2 [00:39<00:00, 39.19s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Start epoch\n",
+      "Start testing\n",
+      "Start generation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "train l: 0.137, test l: 0.136: 3it [01:18, 39.17s/it]                 \n"
+     ]
+    }
+   ],
    "source": [
+    "# with tf.Session() as sess:\n",
+    "sess = tf.Session()\n",
+    "stat = Statistic(sess, p.data, model_dir, tf.trainable_variables(), p.test_step)\n",
+    "stat.load_model()\n",
+    "init = tf.global_variables_initializer()\n",
     "\n",
-    "with tf.Session() as sess:\n",
+    "sess.run(init)\n",
+    "stat.start()\n",
+    "print(\"Start training\")\n",
     "\n",
-    "    stat = Statistic(sess, p.data, model_dir, tf.trainable_variables(), p.test_step)\n",
-    "    stat.load_model()\n",
-    "    init = tf.initialize_all_variables()\n",
+    "initial_step = stat.get_t() if stat else 0\n",
+    "# iterator = trange(p.max_epoch, ncols=70, initial=initial_step)\n",
+    "iterator = trange(2, ncols=70, initial=initial_step)\n",
     "\n",
-    "    sess.run(init)\n",
-    "    stat.start()\n",
-    "    print(\"Start training\")\n",
-    "    \n",
-    "    initial_step = stat.get_t() if stat else 0\n",
-    "    iterator = trange(p.max_epoch, ncols=70, initial=initial_step)\n",
+    "for epoch in iterator:\n",
+    "    print('Start epoch')\n",
+    "    # 1. train\n",
+    "    total_train_costs = []\n",
+    "    for idx in range(train_step_per_epoch):\n",
+    "        images = binarize(next_train_batch(p.batch_size)) \\\n",
+    "            .reshape([p.batch_size, height, width, channel])\n",
     "\n",
-    "    for epoch in iterator:\n",
-    "        print('Start epoch')\n",
-    "        # 1. train\n",
-    "        total_train_costs = []\n",
-    "        for idx in xrange(train_step_per_epoch):\n",
-    "            images = binarize(next_train_batch(p.batch_size)) \\\n",
-    "                .reshape([p.batch_size, height, width, channel])\n",
+    "        _, cost = sess.run([optim, loss], feed_dict={ inputs: images })\n",
+    "        total_train_costs.append(cost)\n",
+    "    print('Start testing')\n",
+    "    # 2. test\n",
+    "    total_test_costs = []\n",
+    "    for idx in range(test_step_per_epoch):\n",
+    "        images = binarize(next_test_batch(p.batch_size)) \\\n",
+    "            .reshape([p.batch_size, height, width, channel])\n",
     "\n",
-    "            _, cost = sess.run([optim, loss], feed_dict={ inputs: images })\n",
-    "            total_train_costs.append(cost)\n",
-    "        print('Start testing')\n",
-    "        # 2. test\n",
-    "        total_test_costs = []\n",
-    "        for idx in xrange(test_step_per_epoch):\n",
-    "            images = binarize(next_test_batch(p.batch_size)) \\\n",
-    "                .reshape([p.batch_size, height, width, channel])\n",
+    "        cost = sess.run(loss, feed_dict={ inputs : images })\n",
+    "        total_test_costs.append(cost)\n",
     "\n",
-    "            cost = sess.run(loss, feed_dict={ inputs : images })\n",
-    "            total_test_costs.append(cost)\n",
+    "    avg_train_cost, avg_test_cost = np.mean(total_train_costs), np.mean(total_test_costs)\n",
     "\n",
-    "        avg_train_cost, avg_test_cost = np.mean(total_train_costs), np.mean(total_test_costs)\n",
-    "\n",
-    "        stat.on_step(avg_train_cost, avg_test_cost)\n",
-    "        print('Start generation')\n",
-    "        # 3. generate samples\n",
-    "        samples = generate(sess, height, width, inputs, output)\n",
-    "        save_images(samples, height, width, 10, 10, \n",
-    "            directory=SAMPLE_DIR, prefix=\"epoch_%s\" % epoch)\n",
-    "\n",
-    "        iterator.set_description(\"train l: %.3f, test l: %.3f\" % (avg_train_cost, avg_test_cost))"
+    "    stat.on_step(avg_train_cost, avg_test_cost)\n",
+    "    print('Start generation')\n",
+    "    # 3. generate samples\n",
+    "    samples = generate(sess, height, width, inputs, output)\n",
+    "    path = save_images(samples, height, width, 10, 10, \n",
+    "        directory=SAMPLE_DIR, prefix=\"epoch_%s\" % epoch)\n",
+    "    iterator.set_description(\"train l: %.3f, test l: %.3f\" % (avg_train_cost, avg_test_cost))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'run/mnist/pixel_cnn16/samples/sample_0.jpg'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "with tf.Session() as sess:\n",
-    "    samples = generate(sess, height, width, inputs, output)\n",
-    "    save_images(samples, height, width, 10, 10, directory=SAMPLE_DIR)"
+    "# with tf.Session() as sess:\n",
+    "samples = generate(sess, height, width, inputs, output)\n",
+    "save_images(samples, height, width, 10, 10, directory=SAMPLE_DIR)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAEYARgBAREA/8QAHwAAAQUBAQEB\nAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1Fh\nByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZ\nWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXG\nx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+iuk8K+A/EfjN5Ro2\nnSSxRI5a4f5ItyqDs3njecqAP9oE4GSM/X/D2p+F9UbTNYgjgvFQO0SzxylAem7YxAOOcHnBB6EV\nl1JBBNdXEVvbxSTTyuEjjjUszsTgAAckk8YongmtbiW3uIpIZ4nKSRyKVZGBwQQeQQeMVHRRRRRX\nrHwOTVNI1jVvFa2e7QrDT5xfzEfMwCiTZFyAZMopOeApOSCVz5PRRRRRRRRRRWxoPhXXfE/2z+xd\nMnvfscXnT+UB8q9hz1Y4OFGWODgHBrHoooooooooorvH+Jk1h4OtNA8L6XHoEgRBf6hazE3F4y8g\nlwAyjcWOMnAIUELkHg6KKKKKKKKK9o8A/FTw3ovw6fwlf2k9ldT+dE9/HaR3EJ83IEsqEgvtBAK4\nbKoBznA8XruPEGleCbDwDY3Gkav9v8QzXax3KrJIUjREbeUDRRkKxaM/MD0IUnaxPD0UUUUUV2ng\nr4XeI/HlvNd6WtpDZxO0bXN1NtUyAKdgChmzhwc4x15zxVPxf4A13wP9m/tqOBPtMs0cHlSh/MWP\nZl+OineMZw3ByBxnvJ/Fmv8Aw6+FfhzSbbRNNjg1uyuJ5rm4RZjMZHOPkBwSImiPzhgQyqR8pFeN\n0UUUUUUUUUUVqWVrpE3h/VJ7vUJINUgeA2VsIiy3KksJQSBhSo2MCT2Iwc5Fzwd4RvPG2uf2RYXl\njbXRiaVPtkpQSbcZVcKSWwScY6Kx7Vc8UfDbxX4QR59V0qT7Grsv2yAiWLAYKGJXlASwxvCk56Zy\nK5Oiiiiuk8AaJN4h8eaNpsH2Te9wJCLuMyRFYwZGDIMbgVUjbkZzjIzkanxW8F2/gbxk1hZz+Za3\nUX2uFNhHkI0jhY8liW2hR8x6+lcPRRRRRRRRRRXeW/xPvrm/8M3fiO3k1p9BuJZojJP5TSApGIwW\nVcko8e/c24tnB99DxF8XR4h8a6dr0/hjTZLS1t/s8theJHcCZSxZj5hjBU9NvXaQeoZgcP4ieJfD\n/iXXIpvDfh6DSLGGIR/JEsTzHqSyIdgwSQMZJ7k8BePr0TVvhjaaF8PtP8Sal4ptILzUbdZ7TTjb\nu3m5AcKHBJztIySu0MQCQCGrzuiiiiiiiiu4+GvxE/4V5qN9df2NBqP2uJY8tJ5UkeDn5X2t8p7r\njkqpzxzz58S3qeI5tctYbGzuJN4EMFnGIER0KMgiIKldhI5BznJJPNdZ8Q/izffEDRtM06bT47JL\nZ/OuPLk3rPLt2hgCuUAy/G4/e5JwDXndFFFFeieA/ikPCDtJf6BaavLEiJYyny4Xs1CsrBGEZOG3\nZIyMkuxyXYnl/GHiWbxh4sv9ent47d7t1IhQkhFVQijJ6naoyeMnPA6Vh0VoS6VeaZ9hutW0u+is\nbrEkZZDD9oj4J8t2Ug8EfMAwGQcGs+rmlapd6LqlvqVg8aXds++J3iSQK3Y7XBGR1BxwcEcgVc8S\neIrjxPqMd/eWljBdCIJM9pbiL7Q+SWlkA4MjFjkjHbgVj0UUUUUVoWs2jpp06XljfS3x3eTNDeJH\nGnHy7kMTFsHJOGXI4460anNo8vlf2TY31rjPmfa7xLjd0xjbEmO/XOcjpjnvLz4j2Ot+FbXR18DW\nl1q1no/9nRajLJ5zRxIg3yBAgwVVGYHPyZJzjdnk/EPgfxL4VlEes6RPbZi87eCsiBNwQkuhKjDM\noOTxuX+8M5epT2NzcLLYWUlmhQGSJp/NUPk52ZAKp0AVixGOWajSrq0stUt7i/0+PULRHzLavK8Y\nlXuNyEFT3B9QMgjIMmsXOl3V4kmkadPYW4iRGimuvtBZwMF92xcbuCRjqTjAwBTgha5uIoEMYeRw\nimSRUUEnHLMQFHuSAO9R0UUUV3Hw1+HFx8RNRvoVvfsNrZxK8lx5Ql+djhU27lPIDnPbb7iuX1ax\nsrG8ljsNXg1K3ErJHLHFJGWQBSHKuoxncRjJwVbttLaHgrw3/wAJd4qttDEnlyXUU/lOWwBIsLum\n44Py7lXOBnGcc1z9WLO1+1ylTcQW8a7TJLM+AilgucDLNjcCQoZsAnGAa6D4iWWhaf471K18NPA+\nkJ5X2cwTmZDmJC2HJOfmLd+OlcvRRWhoV1Z2PiHTLzUbf7RYwXcUtxDsD+ZGrgsu08HIBGDwaz67\nzxz8TL7xfoOi6GRILPT7eEzSTnfLc3Kx7WkZuTjJbAzk5JPJAXg6KKKKKKKKKK9Y8LeGdR1P4G66\n+jiBprrUI/tjiZU/cwqXKSmYokaqSsgdGYncFOADjD1HW9I0r4ZaBpGkeXH4ga9/tLULu3kO+JkD\neQN44zskBwrfIVYEBia5e/8AEuvaqmzUdb1K8QoU23F08g2llYj5ieNyIceqqewrLqxY2F5qd5HZ\n2FpPd3UmdkMEZkdsAk4UcnABP4VXooooooruPhx8Srz4d3l40OnwXtre7PtEbuUf5A+3awyBy/OV\nOcY461yerXkOo6zfXtvaR2cFxcSSx20eNsKsxIQYAGADjoOnQV2nhDxX4f8AC3gHxHDJbT3XiHWY\npbGPCqEggKAbi5GRku5IGc+UudvBPn9FdpfwfDm31TzLO58QXemNZEpDujjuBdfKwDsU2CLDFSQG\nYMjHBXaW4+cwtcStbxyRwFyY0kcOyrngFgACcd8DPoKjoooooooooooqSOCaZJniikdIU3ysqkhF\n3Bct6DcyjJ7kDvUdeieFdU034faJb+ILvR7TV9Y1RDJpYnZSlksbupkYZLb/ADEXHyjhTtkzuA5P\nxT4kvPF3iO71y/jgjurrZvSBSEG1FQYBJPRR3r2/4U+HYtZ+Buu6TqcU8dvfyy3MUqQvJ8oVVV1C\ncuyyQMfLB3HaMjDrnwzRNEm1p77y/MWKyspryZ0jMhVUXj5RzguUUkfdDFjwprLorpPBfjC78Fap\neajYiQ3E1lLaxlWQBGbG12DI24KwDbRjJAycZB5+eea6uJbi4lkmnlcvJJIxZnYnJJJ5JJ5zUdFd\nh410LwtomnaB/YGuf2pfXNp52obJA8cTELgL8ilcnzPlb5gAMgZ54+iiiiivRPCPwb8R+LbCW7SS\n008G3jntku5MNOruQrFVyyIQjkMR82BjIJK8Hf2Nxpmo3NheR+XdWsrwzJuB2upIYZHBwQelV6KK\nKKK7T4V+GrHxZ48s9K1O0u7izZHll+zybAgQbsudpOwkBOCpy4wwPB9I+K/hDU9F8HLoeg6DaQeF\nrC4bUpdQe9j8xnbcAjBtpyu8oPvlgIxnIIrwOirFhY3Gp6jbWFnH5l1dSpDCm4Dc7EBRk8DJI616\nYnwRvoPBF34h1fX9N0yW2dw1vK3mRoEfYweWMth9wYBFVjnC9SQPK6K7z4ReJdX8PePLKPTLe7vY\nr5/JubC3IzOuDhvm4BTJbJIwAwLKCxqT4teKL/xT4hsrnU/C8+g3UVoIxHcmQySpvYg/MqjaDuxh\neu7JPAHn9FdhcfFDxdc+Eo/DLaps01Ivs5EcSI7QhVVYywGdoC/U7mDFhwLnwm8YWPgjxVdavqLy\nfZzZPCYoofMkmLOmFT5lCkY3EscYUjGSK4/VtSm1nWb7VLhY1nvbiS4kWMEKGdixAyScZPqap0UV\n1HjHwTceC/7OhvtRsZr+4iL3VlBKHksn4ISQD1VlIPc7sZADNy9FFFFFFegaV8SU0b4X3vhay0iC\nLUr7zIZ9RiRVZoCQQHyCZGw8yfw7VK4yc15/XcW3wf8AH11t8vw5OuYkmHmyxx/K+cD5mGG4OV+8\nvGQMjPFzwtbXEsDmMvG5RjHIrqSDjhlJDD3BIPaiCFrm4igQxh5HCKZJFRQSccsxAUe5IA717Jf/\nAAe0u98G3Ou6Zr9iW0fT3+1/YB9ohu544zKzK/nErkMqEFV5UsEAYCvF6KKKKKKKKK1LPw3rWoaN\ndaxZ6Xd3Gn2r7J7iKIssZ2ljnHYKMk9FyM43DOXRRRRVzStKvtc1S30zTLaS5vLh9kUSdWP8gAMk\nk8AAk4Ar3fUf2dbG8urddH8RxwiBI4NQRofMKyiLLOo35BYmNvLJ4DkhsbVrzjSfBugzfD7XfF1/\nq92ILW4ksdPtkiSOSebCGNmyzDGHJZFyQFYhjjnj4Bpp0u8NxJdrqAeM2ojRWiZfm8wOSQVP3SpG\nehBHIIp0UVJBGs1xFE80cCO4VpZAxVAT947QTgdeAT6A1HRRUkc80KTJFLIiTJslVWIDruDYb1G5\nVOD3APao6K9g+A/g/S/Et5rl7f20FzcWEUaWsd3F5sCvIJBvePI342DAyOp74IufFk6vodu8Oo/F\nG71PUpU+ztpVpbi3XyyMsZljk2qCr/xKS2QOQCV8fsNJ1LVX2adp93eOXCbbeFpDuKswHyg87Uc4\n9FY9jXceF/h7Cnifwovim5tI9N1e3lv3gS6CyR28cbSK0p6IjheoOcBuVI4p+IPiZrN7/a+l6Ncf\n2Z4avJWEWnW8CRKkXA2jGSm4DLqrbSzPx8xzw9FFFFFFFFaGjaHqniHUUsNIsJ726bB2QpnaCQNz\nHoq5IyxwBnk17vrmu+Hfhx4B1jwZHewPq7aVFazabDbyKDdSoRNP55T59yyIQCRgRBRjOB88V1Hi\nvwvpfh/TtGudO8UWOtSX8TSTx2gx9mICEA5bdzuP3lU/KcgHIHL0VYhv7y3s7mzhu547W62/aIUk\nISXacruUcNg8jPStzwl4vm8Gvd3mn6faSatKgjtr24UubRSrByidN5yvzHOApGCGNex/Cr4V3l5o\n+q634lu5/wDiotP8uMwXZ84xytvZ5Gx95tsZHzEEMwcHJFeafEnxnY67cWmh+Go5LTwtpSeXaW4+\nVZXyczEYzk543EnqTguwrg6KkE8y2726yyCB3V3jDHazKCFJHQkBmAPbcfWo6KKK3PDPhLV/Ft6b\nfTIY9iPGs1xPII4ofMcIm5j3LHAUZY4OAcV3njf4I3HhTQ7jULDWf7Ymtdkl1ax2ojeCBt/74jzG\nO3KEdOzHoprg9f8ACGueGLewuNWtI4YNQQvayR3EUyyqApJBjZhjDqc988Vh16ZfeNF8LfDfQvDv\nhHVpEuL1G1DVry3LRyLKW2iIHdlCuzDYA3BUI4cg+Z17h8MfHl/peh6zdN4cgg8PaXFLew/YzJAj\nXX7uPymmdyHyHLbXLt93aDtRR4/rWsXGvamb+6SBJjFFEVgiEaYjjWNcKOF4QcDA9ABxWfRRRRRR\nRRXSeBvCM3jfxLHosE0kDuhczCAyJGoI3F8EbRtzg92KLxu3D2/xdLpHhv4TappPgHW5LOTRntJ7\nyW1z5lws+3axmGAS4KvuQnhQvCnA+cJ55rq4luLiWSaeVy8kkjFmdickknkknnNR0V6pa2/wr8Oa\nXoqa3Hd6/eTpJc3Uun3GAn8McZQMoCEFn5ZZQVXcqhig4u20G48XeLbyy8I6XPLDJLLLbW7MAYoA\nxK72ZsDAKjJbqQMkkZPE/gnxF4O+y/2/p/2P7Vv8n99HJu243fcY4xuXr61n6FZ3GoeIdMsrMwC6\nuLuKKE3CB4w7OAu9SCCuSMgg5HY17f8AG7x1caTeDw7aGA6hNp6pqN5bsFDhw6mNo+WGFZioZ2AE\nxO0tsdfAKKKK2PFPhu88I+I7vQ7+SCS6tdm94GJQ7kVxgkA9GHaseti+ufDclnIthpWqwXRxskn1\nOOVF5GcqIFJ4z/EPXnpWPVizv7zT5TLZXc9tIduXhkKE7WDryPRlVh6FQeor1C5+MlvfN4pW70G+\na38QeWJIYdXMYtwkSx5TEX3m25YnhgFUggHPm+sal/aV4jRyXxtYIkgto726+0PDGo4QNtUbQc4A\nUAZx7nPorU0Dw5q/inVF03RbGS7uyhfYpChVHUszEBR0GSRyQOpFaFt4h8V+ELLVPDiz3enQXqFL\nyxuIADh0wfldcoSrDkYJG30Fc3UkBhW4ia4jkkgDgyJG4RmXPIDEEA474OPQ1HXSa/4g0jV/D+iW\nNpoUljeaZbi3a6F6ZFnUlnYmMr8pMjuww3G4jkbcc3WpoGiN4g1RbFdQ03TxsLtcajdLBEoHueSS\ncAAAnnPQEiPW9K/sTWJ9O+32N/5O3/SbCbzYXyob5WwM4zg+4NZ9FFbmheL9c8NXEdxpF3HbSRpt\nUi3ibu3zEMpBcCR1Dn5grFQdpxWhZeOJrH4Zaj4MisYyl/ei6lumkOQoEfyKuOu6NTuJPBIx3FfW\nvEmm3vh+y0TS/D1pYwWz+Y15KVlvZmy5w8yogKYcALt/gHNZ+k+HNX1231C402xkng063a5u5AQq\nxRgEkkkgZwCQo5ODgHBrLorY8LeJLzwj4jtNcsI4JLq137EnUlDuRkOQCD0Y96ueJfH3ijxfbwW+\nu6tJdQQOXjjEaRruIxkhFAJxkAnOMnHU1zdaGoa3qOq2dha31x58enxGC2Lou9I85CF8bmUdgSQu\ncDArPooooooooqxYfY/7Rtv7R8/7D5qfaPs+PM8vI3bM8bsZxnjNdJ49PgtdUtbfwVHdtaQW6pPd\nTu2LmT+8FYAqex6AnooAy3J11HgWbwdFrg/4TO1vp7E4CG2kwik8EyKMOVAO7KNkbcYbPFg+J7WC\nXXZPDHhn7BZ32ni2uUe7nnNtGWUMyupTCs3l5D7gTx91ip5e+v7zU7yS8v7ue7upMb5p5DI7YAAy\nx5OAAPwqvRRRRRRRRXcaXq3gbw1rGoM+iT+J4Ypbf7BJdSm2Rtit5rsozlWfbtRlPy8NzkH0f/hp\nr/qUf/Kl/wDaq8Aor2T4bRr4O+H2u+J/EU0f9g63bvY2+nANuvpVEmAXQExDiVAf9ok4wufG6Kkh\ngmuXKQRSSuEZyqKWIVVLMeOwUEk9gCasalpOpaNcLb6pp93YzsgdY7qFomK5IyAwBxkEZ9jVOrmk\n3kOnazY3txaR3kFvcRyyW0mNsyqwJQ5BGCBjoevQ13niv4l2WvXmrQSeE9Dlt7nzFS9HmPd78HbI\ntw21tofBClF+QBMAV5vXSeCvBWpePNZm0vS57SGeK3a4Zrp2VSoZVwNqsc5cdvWrniT4daj4bguZ\nTq2h6l9jz9sj0+/WSS1w6x/PG21vvuF4BweuK4+iiiiiiiivbPDX2n/hm3VLPQrXUrzUNQ1MwSpY\nI8rRn92W3AKCqGJApwXB3jJ+YquG+s/B258l38M65ZZtJI5obeTzNszbNrpI83OzDgZXDbskcYro\nNZ+E/hq58M3XiOyvJ9Nmu9E/tjT9LQNKkKRxRtMrSMSXyXUA5XG7OGAwPD60ND01NY1yy0+W8gso\nZ5VSS6nkVEhT+JyWZRwMnGRnoOSKz6KsWtheX3n/AGO0nuPIiaebyYy/lxr952x0UZGSeBVeipII\nJrq4it7eKSaeVwkccalmdicAADkknjFdQfhz4jj1nT9KuLaO2ubuy/tCT7Q+xbO33MDJOxGIwAuT\n3GQPvHbVzxx4D07wXp2nH/hJ4NR1O8iiuPstvbN5fkuG/eJNkq67lwOASDnArh67T4YeDJvGfjG1\nt3sJLnS7dxJfsJTEqR84BcAnJIwFHJwcFcFlPG/jfWtWvb3RVvo4dDtriSK3sbCctahA/AVuDIgK\ngrnhRjYqLhRx8EE11cRW9vFJNPK4SOONSzOxOAABySTxitzR/Beu654tfwzaWn/EyileK4DMCkGx\ntrs7DICg9xnPAGSQD0mj+CPFHh34pab4YuGktp75wJTazoy3FnvPmEhsqyFY3Ox15wAVOcVn/FXx\nA3iP4g6jdPa3do9u5tGt7m4WXyzGSuF2jCA4yVBYbixDHNcXRRRXrnwp+LOi+BdLn07UNBkJlcyP\nfWRDSzHjarq5AwAWwQwA/u5LMfL9W1KbWdZvtUuFjWe9uJLiRYwQoZ2LEDJJxk+pqnRXceEfhlqn\njDwlreu2Um3+z+IIBHvN24Xc6LtO4MFK4+U7iwGRyRw9FeieHvhBqvirwnD4g0rVdNaDZJ9ogfzD\nLC6MwKbI0csSoRgOCd4AHQnzuiius0D4leLfC2lrpui6nHaWgcvsWzgYsx6lmZCWPQZJPAA6AVzd\nhdfYdRtrz7PBceRKkvk3Cb45NpB2uvdTjBHcVuaN451rRtU1PU/Njv7zUbJ7GeXUQbglG28/McMQ\nEUANkY4IIqn4k8U6z4u1GO/1y8+13UcQhV/KSPCAkgYQAdWP51j0UV3GnfEy80TwvqPhzSdG0qGx\nvopreS4kiLXbxuXx5kqlQ7KHIBKge1cfYTW9vqNtNeWv2u1jlR5rfzDH5qAgsm4crkZGR0zXQeMf\nFtn4p/s77H4a0rRPs0RE32CEJ58jY3McAYXgbVOSMn5jnjtPgJp98viXU9ag0WS+Frpk4tHZdqNc\n5jxGspG1HKsRnqAx7Zqn4m8E/FvXtRM2uaffXk1z5eQk0TR/IQiZWNti4MpPQcNI3Tea6jWPEnhP\n4b6Zovhi78J2PibULO0Iubu5VNiOZHLpHI0RLqJDKOANuMElgwHi+s6ZFpGovZxapY6lsyGmsS7R\nhgSCAzqu7pnK5UgjBNdp4Y+Jy+CPDD2Ph3SY49WvLdlvdRmkZsyiRvKZEJK4WNiOgyzAkEL8/ndd\nx8O9Q0Lw7/a3ibVTBPqGnxKuk2MsZfzLp922TAYfKmzknpuBBDBc6nwe1uxi8a30esalqUN5rtu+\nnRXUAy4lmYHzDJncr7lUA7W5bJIA5uWnxGt4Pi5ca3q1h9it9OtLix0uA2xQ6eEVxErQqRublkKF\ngAZD8yhRjy+/vrjU9Rub+8k8y6upXmmfaBudiSxwOBkk9K6TwP4Qh8TXF5e6pqEeneH9LRZdSvGY\nblViQqIvJLsQQOD9CcK2Pr9lpGn6o1vouryataKgP2prQ24Zj1CqzE4HAycc54xgnPggmuriK3t4\npJp5XCRxxqWZ2JwAAOSSeMVqaz4V13w9Z2N1rGmT2Md95n2cTgK7bCA2UPzL1H3gM5yMiseiiivT\nPgdaNceNb2eLTrTUZ7LTJbqC2uEUmSVGTywjscRPuK/OQcDPHOR5/q2pTazrN9qlwsaz3txJcSLG\nCFDOxYgZJOMn1NGlac2rapb2CXNpbGZ9vn3c6wxRjqWZ24AA/E9ACSBWh4t8Or4V8QS6ONUtNQlg\nRRPJa7tscuPnjJI5KtkZHtnByoI/GGvxeE5vC66lIdFlfe1qyKwB3B/lYjco3KDgEDOfU5w6KKK2\nNR8SXmp+HNF0OaOBbXSPP+zuikO3muHbcScHBHGAPxrHooqxew28E6pa3X2mMxRuX8sph2RS6YP9\n1iy577cjg1XroPD+raFp+j6/baton9oXd5aCKwn80r9lk3Z3Y/I5HPybfuuxHP0UUUVoaHo9x4g1\nyy0i0eCO4vJVijaeURoCfUn+QyT0AJIBk8Q6HN4c1ubS57q0unjSNxPaSF4pFdFkUqxAyNrDnFZd\nFFFFFFFFFWLqwvLHyPtlpPb+fEs8PnRlPMjb7rrnqpwcEcGq9bGi+JtR8P2erW1gYFXVLQ2c7vCr\nOIyRuCsRlcjIPY5zjIUjHrQ1PQtY0Tyv7W0q+sPOz5f2u3eLfjGcbgM4yOnqK6zwLH8PrfRtU1Hx\ndNJd6giOtlpIE0ayEKGDGWMcFm+UZIC4JIORjg6KK9Y8L3XgbQPg9qWo31vpWseI7yVoEsrtD5kO\nflUD+IKFLSb025JC7gwGOH8O+DtU8T6drV/Y+Qlro9o11dPM+OAGIVQASWIRsduOSOMx6+PCq29g\nvhyTWZJwhF6+opEis2FwY1QkgZ35BJxxyeaw6KKkAh+zuzSSCcOoRAgKlcHcS2cgg7cDBzk8jHMd\nFFaH9hax/Y/9r/2Vff2Z/wA/v2d/J+9t+/jb97jr14rPor0DxRHonhTwpL4RgMGoa613Ddz6olnE\nY/IeBHEcMxYuV3FSGAXIJ4wTnz+iitjRtNfVbO+tbDSb7UtWPlmFbaFpBFECfMchOd2fLUZBXDPk\nZ2keqWfwr8ERa3B4Qv8AXNSuPGBt3eSG3IitRKEEix72iYgFTndzwrEgEhTw/iP4WeLfDVheape6\nVJHpdu4H2iSaDdtLhVJRJGIJJHAJxnqetcXRRRRRVi6v7y+8j7Zdz3HkRLBD50hfy41+6i56KMnA\nHAqvRViwvrjTNRtr+zk8u6tZUmhfaDtdSCpweDggdauav4k1rxAlomsapd3wtEZIftEpcqGbceTy\nST3POAo6KAPQPg3o+p2d1qXjdVjj0vSbK6LTNBHOWlWIHYqF1YHDBtwK5AK7huNeb6rql3rWqXGp\nX7xvd3L75XSJIwzdztQAZPUnHJyTyTVOiirEN/eW9nc2cN3PHa3W37RCkhCS7TldyjhsHkZ6VXoo\noorvPBnwp1rxfpb6y1xaaXosT/vL29YqCi58x0GMEKAcklRnjPBxxd/a/YdRubP7RBceRK8XnW77\n45NpI3I3dTjIPcVXr1zxhFq+k/APwVZy+XHaXDzSTRNAJC29zLC6ybSEOwtwGViHIwQGx5HRRRXQ\neDvB2qeONc/snSfIWZYmmkknfakaDAycAk8lRwD19MkZ+uaS+g65e6TLcwXE1nK0MkkG7ZvXhgNy\nqeDkdO3GRg13Hwo8U6N4Fl1fxHf3nm332RrW10uOJ985ZkbcZMbEUFQOpP3jjgBub1bxdNP43vvE\n+hwyaNPdPI4WOcyNG0iFZSHIByxZzkAbd3GMCtjwhPN498T2uh+MPFGstpZSWcmS7LqjRxs24mRi\nqAKGO7B9OMkjg6KKKKKKKK0NP0LWNXx/ZulX17ndj7NbvJnbt3fdB6b0z6bl9RWx4L8Aa748vJ4N\nHjgEdvt+0TzyhEi3BiuQMsc7CPlB98Dmq/im7xLZaKNL/sxtHiNpcwC480SXQYiaYnpuYhQcZ4RQ\nDgADn6KKKKK2NT8QPquj6bYXGn2KSafEIIruFGSRogzttYBvLPLkltm4nkknOceiiuw1jx19s8Da\nX4U0nTv7KsYP3l/5U+/+0JsL+8f5QRyCdpJH3R/AuOfutC1ix06DUbzSr63sZ9vk3M1u6RybhuXa\nxGDkAkY6is+vVNI+PnjDT0u2v549TndFW3E8cccUR3ZZmWNFZyQMD51AySQ3GPP/ABHr994p8QXm\ntak0Zu7pwz+Wu1VAAVVA9AoA5yeOSTzRrepWOpPYvY6VHp5gsobe42SbhcSou0zYwApYAZA7gkkk\nk1nwQTXVxFb28Uk08rhI441LM7E4AAHJJPGKsarpd3ouqXGm36Rpd2z7JUSVJArdxuQkZHQjPByD\nyDVzRtb13wdrCX+mXE+n33lDBKD5o3UMMqwIZSCrDII+6R2NZc8zXNxLO4jDyOXYRxqigk54VQAo\n9gAB2qOiiipBCzW7zgx7EdUIMihssCRhc5I+U5IGBxnGRmOiivZPBXwNh8ZeCNO11dfks57p5i8Z\ntRIoVXKKB86nOUYk99wGBjJ8boorqLP4ieKtP8Lt4atdV8vSGikhNv8AZ4jlJCxcbiu7nc3fjPFd\nJ8PPEM3hr4b+Pr20uY4LyRLK3t2ZyrbnaVSUwQd4Uuwx0256A1x/g/w1N4w8WWGgwXEdu927AzOC\nQiqpdjgdTtU4HGTjkdaj8V6ZZ6L4t1bSrCaea1s7uS3R51CudrFTnBwcEEZ4z1wucDHoorrPBPw/\n1fxtfwJa+XbWD3AgkvZmAVW2M5VFJBkcKpO1enBO0HNc/q1nDp2s31lb3cd5Bb3EkUdzHjbMqsQH\nGCRggZ6nr1NU6KKKuaTHDLrNjHcCNoHuI1kEhAUqWGckugAx/tp/vL1Htn7Q3iG4sZdK8H2C/ZNM\nW0W4lihIVJBuKxptA4VPLJAzg5HHyg14PRRRXonw+gsfD2kX3jm91yOxvLdLmz0e3VN7zXfkH5mG\n0jYokX2yw3EDAbh9M1KbSb2O9tVjF3C6SW8zAkwyK6uHUZwT8uMMCME8ZwRoeLfFFz4x8QS61e2l\npb3cyKsv2UOFcqNoYhmbB2gDjA4HGck4dFdQ3gHW5PD2ma3p8X9pWuoStBGlnFKZFlCFyuxkBbAV\n/mTcuUYZ4rm54JrW4lt7iKSGeJykkcilWRgcEEHkEHjFR0Vc0oaa2qW41iS7TT9+ZzaIrS7fRQxA\nyemT0znBxg7HiiTwabeyi8Jw6yHV5WupdUMe5gQmxV8s4wMOegPzdTxjDurKWz8jzXgbzolmXyZ0\nlwp6BthO1uOVbDDuBXoE/itL/wCFWheH/EFt9ntLbVYpYHs1VJri0AlWVgmNu5WbAc4DsT1ZHNc/\n4gTwONDsZPDr65/a0u17mK9aJ4YR8wZAyqpZshSDjBU84OQOXruP+EE0u3+H/wDwk174usUupYvN\ntdLgj3TSjd5fIdkIw4cMQrABCQW6Vw9SEQ/Z0ZZJDOXYOhQBQuBtIbOSSd2RgYwOTnjpPAfjJ/BG\nuT34svtkNzaSWk8SztA+xsHKSLyjAqvI98YOCOs+FnhjQ/ECeIvFPjl5JdJskHmTXDyqJZnbczeY\nrAs4wBt5LGVe+M+Z381vcajczWdr9ktZJXeG38wyeUhJKpuPLYGBk9cVXoruPhprFvZ68INT1++0\nqziinurSWKQmGC7ERCyvHkb/AJdw2jlztQ5ViDxc4hW4lW3kkkgDkRvIgRmXPBKgkA47ZOPU1HRR\nRRXtnji10zT/ABv4I8O+NUtINJ0zR4luby08xpJwEK7WITds8yPAAGQHY5BbC+V+IbyCS8FjZXUF\n5YWX7q3u002KzeZcAbmCjc3TguS3c4JIrHooqSSeaZIUllkdIU2RKzEhF3FsL6DczHA7knvUdSCN\nTbvKZow6uqiIhtzAg5YcYwMAHJB+YYB5xHRVxdW1JUskXULsJYOXs1EzYt2LBiY+fkJYA5GORmq8\n8811cS3FxLJNPK5eSSRizOxOSSTySTzmo6KK3PEHhDXPCyWz6xaRwJcvKkTJcRShmiYLIPkZsFWO\nCD3yOxrDrvPGvi208R+A/BFks0Z1DSree3uoUjdRGoMaRHJ4JKRgnBPOenSuDoqxYXX2HUba8+zw\nXHkSpL5Nwm+OTaQdrr3U4wR3FWNd1D+1/EOp6lnP2y7luM+X5ed7lvu7m29em5sep61n0V6RrcN5\nafB7wdolvpE8U2r6hcXrhkLSXUi7UiaNQx+VklAxtBJUEDBy3n81heW/2jz7SeL7NKIJ98ZXypDu\nwjZ+63yNweflPoar0UUVc0zSr7Wb2Oz0+2kuJ3dECr0Bd1RdxPCgs6rkkDLD1rY8beHYfCutwaSp\nkF3HZW730byhzHcOgZ1yFAAG4YwXGMHdkkDm67D4leN/+E98Wtqsdr9mtYohbWyMcuY1ZmDPzjcS\nxOBwOBzjJ4+tCW/1HWPsOnzXe6GHENrDJIsUMOcAkZwiZIBZjjJyzEnJqx4h8L6t4VvBZ6xDBBdH\nrCl3FK6cA/MqMSuQwI3Yz2zWPRRRRRRRRRRRRVixsLzU7yOzsLSe7upM7IYIzI7YBJwo5OACfwqS\n80nUtPt7W4vdPu7aC7TfbSTQsizLgHKEjDDDA5HqPWo7GwvNTvI7OwtJ7u6kzshgjMjtgEnCjk4A\nJ/Ci+sLzTLySzv7Se0uo8b4Z4zG65AIyp5GQQfxqvRWx4V8PXHivxRp2h2rbJLuUIXwD5aAZd8Ej\nO1QxxnnGBzVfXdM/sTxDqek+d532G7ltvN27d+xyu7GTjOM4yaz6KKKKsWE1vb6jbTXlr9rtY5Ue\na38wx+agILJuHK5GRkdM1ueOfEOm+JfEsl5o+i2mkaeiCKC3t4VjLKCTvcLxvOe3QADJxk83Wppu\njLqGl6lfvqum2YsUVvIupWWW4LZAWJFUljkc9AMgkgZIy6kggmuriK3t4pJp5XCRxxqWZ2JwAAOS\nSeMUTwTWtxLb3EUkM8TlJI5FKsjA4IIPIIPGKJJ5pkhSWWR0hTZErMSEXcWwvoNzMcDuSe9aGg6F\nc+Ib+S1t3jhSG3lup7iVXMcEUaFmd9isQOMDg5JA71nyRqiQss0chdNzKobMZ3EbWyAM4APGRhhz\nnIHYaF8KfGHiEx/Y9NjRGfbIZ7mONoB5jRlpIy3mKA0cg+7k7GwDij4k+D9I8FeIG0vTtck1CdXY\nz28lsY2tVIVowX+7ISrdVA6dBnA4uiiiiiiiiiug8KeDtU8YXlxFYeRBb2sRmur27fy4LdACcu+D\njODjjsT0BI6jxRY3/iP4f6br1rH4UTTdHiWF7fSGkW5tkkbAE6ycnDhscnJdmG4EtXm9SGNRbpKJ\noy7OymIBtygAYY8YwckDBJ+U5A4zHRXqHh2bVPg9Z6V4ruLWC4uNeiAtrYyZH2TKvIWI+7I37goR\nuABfcM4FY/xK0nTtJutEFn4an8PXF3p4uriylvGn2bpXVPvDcrbUBIJ/iA2gqc8PRRRRRRRRRXqj\nwaD8IPEuhy3umya5r0Vl9ovbaW5RIrK4cqYwu0N86KHzuyDuR1xxjP8AGfxVbxp4aSwuvDum22pG\n486fUIEUmQYAwoZSyEhIgWD5IjA6HA87qxa395Y+f9ju57fz4mgm8mQp5kbfeRsdVOBkHg1XqSGe\na2cvBLJE5RkLIxUlWUqw47FSQR3BIojhaVJnUxgRJvbdIqkjcF+UE5Y5YcDJxk9ASI6K9Y03wX4J\n8VaHpd8dW/4RjVtSu0toNPUyXaSH7m5EYK6q0it8xd0XBUtnIXj/ABn4W07wpdRWdr4hg1W7824j\nuYoYGT7P5cpRdxJ+821iV7Y4LKVY8vRRRRRXSeDvFEPhe41ZriwkvYNS0ybTpEjuBCyLIVywYowy\nAvp3qPxXZeH7SXSpfDl1PPb3Wnxz3CTyrI9vOWcPESET7u0dRznI4Irn6KKKuWmq31le2F5BcyCf\nT3V7Rm+cQlXLjaDkY3EtjGMk+po1XVb7XNUuNT1O5kuby4ffLK/Vj/IADAAHAAAGAK3PAEvhq18U\nJfeK23abZxPOLXyGl+1ygfJFgHAyTu+b5TtweDXeWFv4N1nwd4n8R6zo8dhpMt7byWlnozxzXtk5\nyrlm2jy4nYHCyYXg7VBKFuT8f+BLPwhFZXVtrcFzHqP7+1s2IadLdlUq7shMZ5LLlThtoK5BYJw9\nFFeifDqDTbPwn428SXkUkl3ptlFDYsiqTBNOzKky55V0dUIZSCBuxk4rj9N0DUtQt2v003UpNLhc\ni6vLW0aZYVABck8LkKc4LDtkjrWfPBNa3EtvcRSQzxOUkjkUqyMDggg8gg8YqOiiiivVJ/gF4qj0\naXVLfUNGvoFtzcRrZzSytOu3cBHiPDFh055yK8roq5pWlX2uapb6ZpltJc3lw+yKJOrH+QAGSSeA\nAScAVY1/w5q/hbVG03WrGS0uwgfYxDBlPQqykhh1GQTyCOoNXPBfiGz8K+KLXWrzSv7T+y5eGAzC\nNRJjCsSUbO3kjGCGCnPGDJ4o8Vw+JreyVfDujaTPbPKXfS7YQLMrBNoZeTlSrc5/i6DHPN0UUUUU\nUUV6B8I9M0e48UXGr+IZrFdG0i0e5uY7xUkWXcPLVfLJy3L5yFb5go6stef0UVuah4P1/S7fR57v\nTZAmsoH08RusjXAIUjCqSQTvTggHmsu+sLzTLySzv7Se0uo8b4Z4zG65AIyp5GQQfxqTSdSm0bWb\nHVLdY2nsriO4jWQEqWRgwBwQcZHqKk1vW9R8R6xPq2rXH2i+n2+ZLsVN21Qo4UADgAcCjQ72z03X\nLK+v7D7fa28qyvaFwgm28hWJVhtJxkYORkcZyOw8e/EPR/GWnCKz8G2OkXzXf2ma+hdGkl4bcrER\nqTksGJJPIri9LsF1K/W1e+tLFCju1xdsyxqFQtztBJJ24AAJJIA61TruPh38TdU+H15KIo/tumT5\nM1i8mwF8YDq2DtbgA8HI4I4Uiv46+I+s+PLwm/EEVjHKZLW2SJCbcEYwJNu85ABPOCRnAwAOPooo\norQsL7VPDesW1/ZyT2N/BsmhfbtYBlBU4PVWVh14ZW7g1n0V1HgDxpceA/FCaxBB9pjMTwz2+8J5\nqMMgbirbcMFbgfw46E1J42+IetePXtW1hLRRavI0K28ZUIHVAV5JJGY885OWbnGAOToqxb3X2eC7\ni+zwS/aYhFvlTc0WHV9yH+Fvk25/usw71XoooorUvdSsbjw/pen2+lR293avO91eiTc10XK7cjHy\nhFXAGSOSeCTnLqxfWUun3klrM8DyJjJgnSZDkA8OhKnr2PHTrWp4W16Hw/f3c1xb3dxBdWU9nJDb\nXYg3LKhQ7iUcMADkDH3gp7YMngfVtL0HxpperazbT3FjZy+c0cH396gmMj5l6PtPJ7d+lY9/cJd6\njc3MUXlRyyvIseFGwEkgfIqrx/sqo9ABxXeeF/g34j8Q6Wms3clpo+jlFmN1fSbSYed0iqOwUbvn\nKgggg4ORufEDxBZ+DvFulXvgvWrG/kh0SKwjuPMF49r5bbd6kgxozINuF/vSEqC4J871zxDr/jjW\nbafVJ5NQ1AotrCI4FVmG4lUCooydzHtnmtRPAWo6NZ2uteL7K+0vQpJRGxVF+0ytk/u0jYgqxCsd\nz4UBSfmO1W0NO028+Ieg2Nnaw6Holj4atPLudSvLgxLI0spK73O48ncQv3QxfBG5VHn9FfQeqfBH\nwD4eGlR634tu7KW5cozTSxRrOVjJbZlf3Y3bTliwHC9WU14Jf/Y/7Ruf7O8/7D5r/Z/tGPM8vJ27\n8cbsYzjjNV6sWtheX3n/AGO0nuPIiaebyYy/lxr952x0UZGSeBXcfC3T/Dr3Ws634mFjNY6TaJLH\nbXUkg3zNKqoxVFYtGD8rfKwHmLlTmvP6KK9E+DPh6HWfG4vdRtrSXRdLt5bi/a9QNAFKMqhtwK5y\nd3zY4Rj2rrPEGtaj48+A0usvNY2NvpF2LeXTrbTVWNvmhWLy3Z2ZNqueV25DFcYGW5u7+E0N14OO\nveFvEUevzokMk2m29sPtESydAyxvIQ4PVTjhW5+XB8zooooor3TxBq994m/Zy0+70u/jtrPSki0/\nVrFo9xmKNEsZVyuQQfLfA4xIQSSuD4XXcePPA2neCooLaTxBBca7+7+06ZCjSCFSpy/nYUckAhCo\nYBx94Dc3D0UUUUUUV6B4x+Jeo+LvDllb3OrXy3Riji1CzSBUtp2jeQrKGD53EMmV2BSVz/CoHn9e\nmfA+Oxh+INndanNJZ+YjxadcEYV7kGPdECQVJaN2Ug8/vBjDFDWf8TPiZN8RbjTmbS49PgsUkCIJ\njKzM5XcS2FGMIuBj15OeK+m+OIbD4Taz4Naxkee/vY7hLkSAKqjYWBGM5zEoHrvPTbhuLq5pMdjN\nrNjFqk0kGnvcRrdSxjLJEWG9hweQuT0P0NdZ8WPGNv428czX9jzYW8S2tq5Qo0iKSSxBPdmbHT5d\nuQDmuHqSCCa6uIre3ikmnlcJHHGpZnYnAAA5JJ4xXrGq2Nz8KPB2s+GtV1yS51DWkTZp2nTOkUMR\n3ZnLtHyS0fltGNu5Cck8bYz/AGt4e/Z/tJtO8ibTNdlm/tEXnlN5EiyhI/IU4Ysyx5PDldm5dmM1\n5PXQeE7Hw1d6xbjxTq89lpr+YJDaRM8iEKCpJ2kBWJIyA5ypBCghqz9b/sf+2J/7A+3f2Z8vk/b9\nnnfdG7ds+X727GO2K6DwH4p0Lw3LqUWu+Hv7XtdSiS1lInKGKHdufauMM2QjA5UgoMMM5rqPGXxS\n0yfQ7TR/A66rpVgtpJZT2cyQiAwv975fnZpG7uWBGDjl2NSfDzXdI8C/D7U/E8N7HeeIpLjyotNG\noGJY1A2q8kOVMoBdjwH/AIcFCHK+R0UUV1nw8j8Hv4lZvG00kelpbuyKokxJLlQFbywWxgseMcqO\nex9I1TxJY/Fmy1PSvtMfhvwloSQ3sFy+m7igVDH5blZdqkl22IqksBgcjB4Pxj8QP7a0fTvDmh28\n+meHtOiMKwmb57v5gRJMqYQsSobGDhixyc8R+AfhtqXxCTVTp15aW72CRHFxuxIzscDKg4G1XOee\nQoxySOTvb641CdZrqTzJFijhB2gYSNFjQceiqo98c81XoroPBnh6z8UeI49JvdV/suOSKWQXTQiR\nE8tC7b8uu1dqsd2T0HGDkYc8LW1xLA5jLxuUYxyK6kg44ZSQw9wSD2qOiiipBIot3iMMZdnVhKS2\n5QAcqOcYOQTkE/KMEc5jooooooorQ0nWbzRJZ57B/JupYvKS5QlZYPmVi0bAgqxClSf7rsO9R6lq\n2pazcLcapqF3fTqgRZLqZpWC5JwCxJxkk49zQdVvm0ZNHNzJ/Z6XDXQtxwvmsoUufU7VAGenOMZO\ne4+D1lpD+Jb7VfEVjaT6Hptk8tzNeAmKFiQqfLtIdzkhUPXkjLKAcfx94j0XxHrMc2haFaaXaQoy\nAw24gaYFiRvjVmQFQQuRy2CTgEKnJ0UVqDw3rTeH314aXd/2SjqhvDERHliVGD3G5SpI4BwDgkA5\ndFFFFdhpfifR9N+HGuaAlnff2nq/k+bO0qNCPJmV02rgMMq0gOSeVXH3jt4+vTPgv4rudG8SyaDF\npsl7Br7xW0pgleKWAAkGRWTkBVd2OMEYB3Lg15nRRXYeBPFdh4N/tfUzbTza61oYNKkVYzHbu+Q8\nrbgSGAxjAOQWU8HI5ewsbjU9RtrCzj8y6upUhhTcBudiAoyeBkkdak1XSr7Q9UuNM1O2ktry3fZL\nE/VT/IgjBBHBBBGQap13ni/4U614J8K2OtatcWm+5uBA9rExZoiyb1y2ME/K4OOBgYLZ4pw/DvVJ\nPANz4qkmgiWOVUisiczyoU8xnCjphCJAD1jDPwoBbj6kIh+zoyySGcuwdCgChcDaQ2ckk7sjAxgc\nnPEdFFFFFWHtvKs1lmWeOSXD24MWEljy6swYnsy7RgEH5uQVwa9FFFSQCFriJbiSSOAuBI8aB2Vc\n8kKSATjtkZ9RXeXHxE0drzQ3tfAeh29rp0shntmiSQXkZG1Fd2TduVCfmJYM+HK8AVzfi3XLHxF4\ngl1HTtCtNFt3RVFpanKggYLHgDJ/2VUdOCck4dFFFFd5H8GfHszzJFokbvC+yVVv7YlG2hsN+84O\n1lOD2IPeuX1vw5q/h248nVbGS3Jd0V8h43ZDhwrqSrFScMATtPBwRisurH264/s77AZM2ol85UZQ\ndr4wSpPK5GM4xu2rnO1cV6KKKKKK3PCPhe+8Y+JbTR7COQmVwZpVTcIIsjdI3IGAD0yMnAHJFe/y\nXlzpXwh8NyXWgyeLtS1F4rtrfUZXvSwZdzFC6H5/LOBGoyoLt84SRj4p4u8beOdX3aR4n1C+j8rH\nmWUkIts52sPMRVXd0UjcDjqOtcfRRXSeBdCsfEPidLXVnu4dJht57q+uLVctBFHGzbz8rYG4KOhz\nkAckVY+Ius6VrnixrnQ9KtNM01beJYIbeKOMsCu8s4jZl35cjrkAAEAgiuTqSCFrm4igQxh5HCKZ\nJFRQSccsxAUe5IA716o3w68Ha5rGmeHPB3iG+1LV2lYajdtDm0gijU+ZIMKM5baEwzKc4Lcgnk/i\nD4nh8R+JZl0xI7fQbN2i020gQRxRx5+Z1QKuC7Zc5GeQCTtFHw8j8Hv4lZvG00kelpbuyKokxJLl\nQFbywWxgseMcqOex3PFE3w1sfCUcfhfTZ77Unu5rY3mozOH8tVz5oRJFAyZE2bkwdjblyOfN60ND\n0a88Q65ZaRYJvuruVYkyCQuerNgEhQMknHABNWNY8LazoOuJol/Z7dTfYFtYZUnfL/dXEZb5jxhe\nvIOORWXPBNa3EtvcRSQzxOUkjkUqyMDggg8gg8YqOiiug8L+EbzxV/aTW15Y2sOm2jXlzJdykYjX\nqQqKztgeikDgE5IB7zwT/wAIe/giDSbK10bUfGmr3Agki1pJBHChdlHluFAU7MN8rhiW4LMFQ7Hj\nTwh8NobiLw3aPaaB4gjeF724lvJ3gtlYxgqDIMSkiUEYCcKWZkCkHn/h/wCANV8b3/8AwlvieaOT\nQYnJu7rVLiTdcoiEMVYMDhdoG8sAMfxbWWuf+J3iqx8UeLJG0aGODRbRFgs444vKVwqqpkKdASFV\nQcA7EjBA24ri66CXwP4lt9Dv9ZudInt7GwlWG6acrG8TtsIBjYh+RIh6fxVz9FFFFFFamgeI9X8L\naoupaLfSWl2EKb1AYMp6hlYEMOhwQeQD1Ar1TxDda78KvCXgV9I1udpLm0upZYRMJLbfIqkMqhir\nbfNGOShKBwuWbdy9v4ci1f4da54717U77UbxZY7W3Ecrs6zfdP2hnjb5QpjIIbB+7uDEAef0UV6B\n4JttU8OaHf8Aiu90qeXwzqET6NeSRcTeVNw8sWRt+VlUbm+UswXrkrc+IHwjbwJ4Vs9afV5Lh7m4\nSBrWS0WNoiyM/LLI4JGzHGR6H18zoqSGea2cvBLJE5RkLIxUlWUqw47FSQR3BIqOiiuk8B+FJvGf\njGw0ZBIIHffdSJn93CvLnOCAcfKCRjcyg9a9E+BVr/ZNn4j8WajcQafpEVo1mdRL5mikJRiEQ5U9\nVPzKSW2BQcsK8jnvZl1mW/t767knFwZo7yQlJ2bdkSEhiQ+efvHB7nrVOiiiirmk3kOnazY3txaR\n3kFvcRyyW0mNsyqwJQ5BGCBjoevQ1Y1fX77xBql7qmsNHeX92iq07LsKldoDKE2rnam3kEYJ4zgj\nQ8Q+Oda8S6NpGj3kscen6VbpBBbwgqrFF2iR8k7n28Z6DnAGTnm69g+FPibwj4V8G67qd0bEeLIP\nNlsTcwu7FRGqxqhxxl3YEKQxXJPyrkeRzzzXVxLcXEsk08rl5JJGLM7E5JJPJJPOajoooooooqQz\nzNbpbtLIYEdnSMsdqswAYgdASFUE99o9K6ifxxM/w3t/BtvYx20CXAuJ7mKQq1y26QkSADDDDQgZ\n6eSOuQF5/TZNNiuGbVLS7uYNhCpa3KwMGyOSzRuCMZ4x3HPHNecwtcStbxyRwFyY0kcOyrngFgAC\ncd8DPoKjrQ/t3WP7H/sj+1b7+zP+fL7Q/k/e3fczt+9z06813Hi74qReIPA1p4U0zRZ9JsbeVGGd\nTe43RqGxGdyglQSpAJIGxQBwMeb0UUUVJNPNcuHnlklcIqBnYsQqqFUc9goAA7AAV1ng74iX/gaX\nztI0rSjcPE0U088UjvKCwYZO8bcYxhNoP8QYhSLHiX4j3GseF7Pwvpll/ZehW0UKG3Eod5HjLkuz\nKqA7yyswKn5kDDBJzw9FFFbiWcPiS/0zTfDmiXaalMixSR/ahKs0gRQXUFQYwSHdsswGeqhap67p\nn9ieIdT0nzvO+w3ctt5u3bv2OV3YycZxnGTWxqfjR77wNpvhS30mxsrO0lFzLLCGMlxOA6+YxJ7q\nwBHPK8ELhRy9SQGFbiJriOSSAODIkbhGZc8gMQQDjvg49DWx4i1XQ9TeI6L4bj0VEdiQt5LcGRSq\nYDF+4YOcjGQ4GPlycOiiu48ZfCnxJ4JitJb1YLyO58zD2AkkEexd7byUGPlDN9EY9BXD0UUUVsaD\n4V13xP8AbP7F0ye9+xxedP5QHyr2HPVjg4UZY4OAcGseiiiiiiipJ41huJYkmjnRHKrLGGCuAfvD\ncAcHryAfUCrmjaHqniHUUsNIsJ726bB2QpnaCQNzHoq5IyxwBnk1Y8Q+F9W8K3gs9Yhgguj1hS7i\nldOAfmVGJXIYEbsZ7ZrQ8A+FE8YeI3sLm5+x2MNpNc3V2WUC3RUOJG3EZUOUyPQnkdR6B8R/E/hr\nQfAln4I8Ez2N3p9zvOoSjc8u+OVNrlxhSzNG2eD8oXaApWvF6KKK1NSs9Ns9L03yLuSfU5kaW8Rd\npigU48pAwJ3Ptyzem5VwGVqy69g+B02hSz6to4ub6y8U6taT2tneoCY4Y9gb5dpBEmQXycDEYAYE\n8+T3/wBs/tG5/tHz/t3mv9o+0Z8zzMndvzzuznOec1XooortPAOvW1vqlnoV/wCGdN1mzv7gwSI8\nCC6Yy7EXy5mIKFSMryoy7ZIJDLsa/wDCTUovEHjEafNpsVhoaG98o3LOwt3EjxoMAkOFTBDkHock\nEMfM69Aj+JtxL8I73wVfxz3UzyxC1uXkGIYFZX2HjJwUAHPR8ZAQA+f1uav4T1Xw+9oms28mnm5t\n2nT7RDIoyF3CPO3BcjZwMhS6hipDBcOitTRfDmr+IXmXS7GSdIELzzEhIoFCs2ZJGIRBhW5YjOK9\nc0bxl4d+HPwqvoPC/iH+0/EV1LGJCY5BFDI4OXSOQLlVVCNwBJbZuGCFHh9dhf6L4Ru/C+lT+HtX\nvpfEcuyO60m4t3dpJGIX9yyJt+9yFJJKkchhtPYaPoPww8PaS+j+OL3zvEbyulw9kZmGnZj4UsmY\n3ZSMHAbDttIIUmuD8Z+DbvwbqiW813aXlpcp51ldW8yMLiE42ybQSVBzjngkNtLAZrm66S28B+I7\nzwdJ4ptdOkl0uN5BI6/eVU25faeWTLEZXONj5xiuboor1D4NwWemawPFGpeJv7FtLe7isdigN9qa\nVXby5OT5cfyA7mXacHDKy5HJ+L9H1KDx1qNo+lalbz3d7I1rbXSs88ivKwTByxkJPG4FtxzgnrXU\nT6LN8PfhleTarZ3dl4k8RP8AZLdTMUMdiBHJISq9CzYRkchsHoAGB8zor2D4xeBtJ8KeHvDt15uP\nEN1uGoHzJZvtkgRTLNvc8Yc9MAt5mf4a8fooq5f6VfaYlm99bSQC9txdW+/gvEWZQ+OoBKnGeowR\nwQTY8N63N4c8S6brMHmF7O4SUokhjMig/Mm4dAy5U8Hgng1X1bUptZ1m+1S4WNZ724kuJFjBChnY\nsQMknGT6mq8EE11cRW9vFJNPK4SOONSzOxOAABySTxitzxp4UuPBXii60S5uYLlosMksLA7kYZUs\nuSUbHVT9RkEE8/RXQeDvFL+Ddc/tq2sYLq+iiZLUzswSJ2wC5VSN3yF1xkfez2rPm1vUbi61S5lu\nN02q7vtrbFHm5lWU8Y+X50U8Y6Y6cVn0VYhuvL+zrJbwTwwymUxumPMztyrMuHKkKON3GSRgkmvW\nP2g7fWf+Eo0y+vpZxpt3aBrO1lKD7K4C+bHhWILZKsW77gASFFeP0V7AmqWHhf4ENH4ZvYLm+1mU\nxatcTJHE8Y8tA8EauQ8m0SoMqHA3SNlcjHj9FeufBW28EWT3niTxNq9pFf6c+62s7khQoC7vNUHm\nV8ggKoJUjOCSpHD6p4qh1b4gt4ouNGtBA96l1JpyAeXIqkEoxIIJYD5mxyWY45xUfjTxZeeNfFF1\nrV4nlebhIYA5dYY1GFUE/iTjALFjgZxXYfHLXNL1Xxbp9pod/Bc6Zp+npCkdo+YIn3MSEx8v3PLB\n2/3QP4cDY1z462dx4SvfDmheE4NOtbq0a3BEoCReYv73bGiAdWfByM8MR1WvF6KK2LfxTrNp4Xu/\nDUF5s0i7lE09v5SHe4KkHcRuH3F6Ht9a6CwsfGPxY1G2sLOPzrXTIkhhTd5dtYQkgKMnk4AHXdIw\nT+LbVf4o6/ceIviLq91cQT23ky/ZUtppRIYRH8hXglRlgzEKSMseT1PH0V7R8ctB8Swz2xTS/L8H\n6LFFaafJEyvsDIgJf5i/3lCZbA+Ve7ZbzPwr4S1fxnqkunaNDHLcRW73DB5Ag2rjjJ7liqj3YZwM\nkV/EmlNofiXUtMa2u7YW9w6JFd7fNVM/Ju2/KSVwcrwc5GQRXefBHwXpfi3xRLcapPBJHpmyb+zp\nU3fagQwz94fKjBCeCDuAPB5Pji2uv4tt/wC2tJ+zRwxG3sr5nDPewo333KnywxJZ9qqpXzACMba8\nvor0T4V2ukaRrdn4w8S6haWek2dw8UCSxGZ7i4CZ+VFBICb0cuRgEoBycjk/Fl9b6n4y1y/s5PMt\nbrULiaF9pG5GkYqcHkZBHWqelXVpZapb3F/p8eoWiPmW1eV4xKvcbkIKnuD6gZBGQes+KuoaXqni\nq0u9L07+z/N0qykuIFOUV2hVlCY42rG0ScBfunjueHooorrPA+teHNEuLyfW7C7e8VFk0y/tTvay\nuFJKuYi6rIMlWwxx8gGCGOMfxHr994p8QXmtak0Zu7pwz+Wu1VAAVVA9AoA5yeOSTzWXRRRX/9k=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from IPython.display import Image\n",
-    "fname = save_images(samples, height, widht, 10, 10, directory=SAMPLE_DIR)\n",
+    "fname = save_images(samples, height, width, 10, 10, directory=SAMPLE_DIR)\n",
     "Image(filename=fname)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -321,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/pixelrnn.ipynb
+++ b/pixelrnn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -11,7 +11,7 @@
     "import os\n",
     "\n",
     "import numpy as np\n",
-    "from tqdm import trange\n",
+    "from tqdm import tqdm\n",
     "import tensorflow as tf\n",
     "\n",
     "from utils import *\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -87,22 +87,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting MNIST-data/train-images-idx3-ubyte.gz\n",
-      "Extracting MNIST-data/train-labels-idx1-ubyte.gz\n",
-      "Extracting MNIST-data/t10k-images-idx3-ubyte.gz\n",
-      "Extracting MNIST-data/t10k-labels-idx1-ubyte.gz\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# TODO add hyperparams to model saving\n",
     "model_dir = setup_model_saving(p.model, p.data, hyperparams)\n",
@@ -134,27 +123,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Building CONV0\n",
-      "Building CONV1\n",
-      "Building CONV2\n",
-      "Building CONV3\n",
-      "Building CONV4\n",
-      "Building CONV5\n",
-      "Building CONV6\n",
-      "Building CONV_OUT0\n",
-      "Building CONV_OUT1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def pixelRNN(height, width, channel, params):\n",
     "    \"\"\"\n",
@@ -192,19 +165,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Building pixel_cnn finished!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "loss = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(logits=conv2d_out_logits, labels=inputs, name='loss'))\n",
     "\n",
@@ -221,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -251,55 +216,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      " 50%|█████████████████████▌                     | 1/2 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Start training\n",
-      "Start epoch\n",
-      "Start testing\n",
-      "Start generation\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "train l: 0.246, test l: 0.138: 100%|████| 2/2 [00:39<00:00, 39.19s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Start epoch\n",
-      "Start testing\n",
-      "Start generation\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "train l: 0.137, test l: 0.136: 3it [01:18, 39.17s/it]                 \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# with tf.Session() as sess:\n",
     "sess = tf.Session()\n",
@@ -313,10 +235,10 @@
     "\n",
     "initial_step = stat.get_t() if stat else 0\n",
     "# iterator = trange(p.max_epoch, ncols=70, initial=initial_step)\n",
-    "iterator = trange(2, ncols=70, initial=initial_step)\n",
+    "iterator = tqdm(range(p.max_epoch))\n",
     "\n",
     "for epoch in iterator:\n",
-    "    print('Start epoch')\n",
+    "    # print('Start epoch')\n",
     "    # 1. train\n",
     "    total_train_costs = []\n",
     "    for idx in range(train_step_per_epoch):\n",
@@ -325,7 +247,7 @@
     "\n",
     "        _, cost = sess.run([optim, loss], feed_dict={ inputs: images })\n",
     "        total_train_costs.append(cost)\n",
-    "    print('Start testing')\n",
+    "    # print('Start testing')\n",
     "    # 2. test\n",
     "    total_test_costs = []\n",
     "    for idx in range(test_step_per_epoch):\n",
@@ -338,7 +260,7 @@
     "    avg_train_cost, avg_test_cost = np.mean(total_train_costs), np.mean(total_test_costs)\n",
     "\n",
     "    stat.on_step(avg_train_cost, avg_test_cost)\n",
-    "    print('Start generation')\n",
+    "    # print('Start generation')\n",
     "    # 3. generate samples\n",
     "    samples = generate(sess, height, width, inputs, output)\n",
     "    path = save_images(samples, height, width, 10, 10, \n",
@@ -348,22 +270,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'run/mnist/pixel_cnn16/samples/sample_0.jpg'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# with tf.Session() as sess:\n",
     "samples = generate(sess, height, width, inputs, output)\n",
@@ -372,23 +283,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAEYARgBAREA/8QAHwAAAQUBAQEB\nAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1Fh\nByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZ\nWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXG\nx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+iuk8K+A/EfjN5Ro2\nnSSxRI5a4f5ItyqDs3njecqAP9oE4GSM/X/D2p+F9UbTNYgjgvFQO0SzxylAem7YxAOOcHnBB6EV\nl1JBBNdXEVvbxSTTyuEjjjUszsTgAAckk8YongmtbiW3uIpIZ4nKSRyKVZGBwQQeQQeMVHRRRRRX\nrHwOTVNI1jVvFa2e7QrDT5xfzEfMwCiTZFyAZMopOeApOSCVz5PRRRRRRRRRRWxoPhXXfE/2z+xd\nMnvfscXnT+UB8q9hz1Y4OFGWODgHBrHoooooooooorvH+Jk1h4OtNA8L6XHoEgRBf6hazE3F4y8g\nlwAyjcWOMnAIUELkHg6KKKKKKKKK9o8A/FTw3ovw6fwlf2k9ldT+dE9/HaR3EJ83IEsqEgvtBAK4\nbKoBznA8XruPEGleCbDwDY3Gkav9v8QzXax3KrJIUjREbeUDRRkKxaM/MD0IUnaxPD0UUUUUV2ng\nr4XeI/HlvNd6WtpDZxO0bXN1NtUyAKdgChmzhwc4x15zxVPxf4A13wP9m/tqOBPtMs0cHlSh/MWP\nZl+OineMZw3ByBxnvJ/Fmv8Aw6+FfhzSbbRNNjg1uyuJ5rm4RZjMZHOPkBwSImiPzhgQyqR8pFeN\n0UUUUUUUUUUVqWVrpE3h/VJ7vUJINUgeA2VsIiy3KksJQSBhSo2MCT2Iwc5Fzwd4RvPG2uf2RYXl\njbXRiaVPtkpQSbcZVcKSWwScY6Kx7Vc8UfDbxX4QR59V0qT7Grsv2yAiWLAYKGJXlASwxvCk56Zy\nK5Oiiiiuk8AaJN4h8eaNpsH2Te9wJCLuMyRFYwZGDIMbgVUjbkZzjIzkanxW8F2/gbxk1hZz+Za3\nUX2uFNhHkI0jhY8liW2hR8x6+lcPRRRRRRRRRRXeW/xPvrm/8M3fiO3k1p9BuJZojJP5TSApGIwW\nVcko8e/c24tnB99DxF8XR4h8a6dr0/hjTZLS1t/s8theJHcCZSxZj5hjBU9NvXaQeoZgcP4ieJfD\n/iXXIpvDfh6DSLGGIR/JEsTzHqSyIdgwSQMZJ7k8BePr0TVvhjaaF8PtP8Sal4ptILzUbdZ7TTjb\nu3m5AcKHBJztIySu0MQCQCGrzuiiiiiiiiu4+GvxE/4V5qN9df2NBqP2uJY8tJ5UkeDn5X2t8p7r\njkqpzxzz58S3qeI5tctYbGzuJN4EMFnGIER0KMgiIKldhI5BznJJPNdZ8Q/izffEDRtM06bT47JL\nZ/OuPLk3rPLt2hgCuUAy/G4/e5JwDXndFFFFeieA/ikPCDtJf6BaavLEiJYyny4Xs1CsrBGEZOG3\nZIyMkuxyXYnl/GHiWbxh4sv9ent47d7t1IhQkhFVQijJ6naoyeMnPA6Vh0VoS6VeaZ9hutW0u+is\nbrEkZZDD9oj4J8t2Ug8EfMAwGQcGs+rmlapd6LqlvqVg8aXds++J3iSQK3Y7XBGR1BxwcEcgVc8S\neIrjxPqMd/eWljBdCIJM9pbiL7Q+SWlkA4MjFjkjHbgVj0UUUUUVoWs2jpp06XljfS3x3eTNDeJH\nGnHy7kMTFsHJOGXI4460anNo8vlf2TY31rjPmfa7xLjd0xjbEmO/XOcjpjnvLz4j2Ot+FbXR18DW\nl1q1no/9nRajLJ5zRxIg3yBAgwVVGYHPyZJzjdnk/EPgfxL4VlEes6RPbZi87eCsiBNwQkuhKjDM\noOTxuX+8M5epT2NzcLLYWUlmhQGSJp/NUPk52ZAKp0AVixGOWajSrq0stUt7i/0+PULRHzLavK8Y\nlXuNyEFT3B9QMgjIMmsXOl3V4kmkadPYW4iRGimuvtBZwMF92xcbuCRjqTjAwBTgha5uIoEMYeRw\nimSRUUEnHLMQFHuSAO9R0UUUV3Hw1+HFx8RNRvoVvfsNrZxK8lx5Ql+djhU27lPIDnPbb7iuX1ax\nsrG8ljsNXg1K3ErJHLHFJGWQBSHKuoxncRjJwVbttLaHgrw3/wAJd4qttDEnlyXUU/lOWwBIsLum\n44Py7lXOBnGcc1z9WLO1+1ylTcQW8a7TJLM+AilgucDLNjcCQoZsAnGAa6D4iWWhaf471K18NPA+\nkJ5X2cwTmZDmJC2HJOfmLd+OlcvRRWhoV1Z2PiHTLzUbf7RYwXcUtxDsD+ZGrgsu08HIBGDwaz67\nzxz8TL7xfoOi6GRILPT7eEzSTnfLc3Kx7WkZuTjJbAzk5JPJAXg6KKKKKKKKKK9Y8LeGdR1P4G66\n+jiBprrUI/tjiZU/cwqXKSmYokaqSsgdGYncFOADjD1HW9I0r4ZaBpGkeXH4ga9/tLULu3kO+JkD\neQN44zskBwrfIVYEBia5e/8AEuvaqmzUdb1K8QoU23F08g2llYj5ieNyIceqqewrLqxY2F5qd5HZ\n2FpPd3UmdkMEZkdsAk4UcnABP4VXooooooruPhx8Srz4d3l40OnwXtre7PtEbuUf5A+3awyBy/OV\nOcY461yerXkOo6zfXtvaR2cFxcSSx20eNsKsxIQYAGADjoOnQV2nhDxX4f8AC3gHxHDJbT3XiHWY\npbGPCqEggKAbi5GRku5IGc+UudvBPn9FdpfwfDm31TzLO58QXemNZEpDujjuBdfKwDsU2CLDFSQG\nYMjHBXaW4+cwtcStbxyRwFyY0kcOyrngFgACcd8DPoKjoooooooooooqSOCaZJniikdIU3ysqkhF\n3Bct6DcyjJ7kDvUdeieFdU034faJb+ILvR7TV9Y1RDJpYnZSlksbupkYZLb/ADEXHyjhTtkzuA5P\nxT4kvPF3iO71y/jgjurrZvSBSEG1FQYBJPRR3r2/4U+HYtZ+Buu6TqcU8dvfyy3MUqQvJ8oVVV1C\ncuyyQMfLB3HaMjDrnwzRNEm1p77y/MWKyspryZ0jMhVUXj5RzguUUkfdDFjwprLorpPBfjC78Fap\neajYiQ3E1lLaxlWQBGbG12DI24KwDbRjJAycZB5+eea6uJbi4lkmnlcvJJIxZnYnJJJ5JJ5zUdFd\nh410LwtomnaB/YGuf2pfXNp52obJA8cTELgL8ilcnzPlb5gAMgZ54+iiiiivRPCPwb8R+LbCW7SS\n008G3jntku5MNOruQrFVyyIQjkMR82BjIJK8Hf2Nxpmo3NheR+XdWsrwzJuB2upIYZHBwQelV6KK\nKKK7T4V+GrHxZ48s9K1O0u7izZHll+zybAgQbsudpOwkBOCpy4wwPB9I+K/hDU9F8HLoeg6DaQeF\nrC4bUpdQe9j8xnbcAjBtpyu8oPvlgIxnIIrwOirFhY3Gp6jbWFnH5l1dSpDCm4Dc7EBRk8DJI616\nYnwRvoPBF34h1fX9N0yW2dw1vK3mRoEfYweWMth9wYBFVjnC9SQPK6K7z4ReJdX8PePLKPTLe7vY\nr5/JubC3IzOuDhvm4BTJbJIwAwLKCxqT4teKL/xT4hsrnU/C8+g3UVoIxHcmQySpvYg/MqjaDuxh\neu7JPAHn9FdhcfFDxdc+Eo/DLaps01Ivs5EcSI7QhVVYywGdoC/U7mDFhwLnwm8YWPgjxVdavqLy\nfZzZPCYoofMkmLOmFT5lCkY3EscYUjGSK4/VtSm1nWb7VLhY1nvbiS4kWMEKGdixAyScZPqap0UV\n1HjHwTceC/7OhvtRsZr+4iL3VlBKHksn4ISQD1VlIPc7sZADNy9FFFFFFegaV8SU0b4X3vhay0iC\nLUr7zIZ9RiRVZoCQQHyCZGw8yfw7VK4yc15/XcW3wf8AH11t8vw5OuYkmHmyxx/K+cD5mGG4OV+8\nvGQMjPFzwtbXEsDmMvG5RjHIrqSDjhlJDD3BIPaiCFrm4igQxh5HCKZJFRQSccsxAUe5IA717Jf/\nAAe0u98G3Ou6Zr9iW0fT3+1/YB9ohu544zKzK/nErkMqEFV5UsEAYCvF6KKKKKKKKK1LPw3rWoaN\ndaxZ6Xd3Gn2r7J7iKIssZ2ljnHYKMk9FyM43DOXRRRRVzStKvtc1S30zTLaS5vLh9kUSdWP8gAMk\nk8AAk4Ar3fUf2dbG8urddH8RxwiBI4NQRofMKyiLLOo35BYmNvLJ4DkhsbVrzjSfBugzfD7XfF1/\nq92ILW4ksdPtkiSOSebCGNmyzDGHJZFyQFYhjjnj4Bpp0u8NxJdrqAeM2ojRWiZfm8wOSQVP3SpG\nehBHIIp0UVJBGs1xFE80cCO4VpZAxVAT947QTgdeAT6A1HRRUkc80KTJFLIiTJslVWIDruDYb1G5\nVOD3APao6K9g+A/g/S/Et5rl7f20FzcWEUaWsd3F5sCvIJBvePI342DAyOp74IufFk6vodu8Oo/F\nG71PUpU+ztpVpbi3XyyMsZljk2qCr/xKS2QOQCV8fsNJ1LVX2adp93eOXCbbeFpDuKswHyg87Uc4\n9FY9jXceF/h7Cnifwovim5tI9N1e3lv3gS6CyR28cbSK0p6IjheoOcBuVI4p+IPiZrN7/a+l6Ncf\n2Z4avJWEWnW8CRKkXA2jGSm4DLqrbSzPx8xzw9FFFFFFFFaGjaHqniHUUsNIsJ726bB2QpnaCQNz\nHoq5IyxwBnk17vrmu+Hfhx4B1jwZHewPq7aVFazabDbyKDdSoRNP55T59yyIQCRgRBRjOB88V1Hi\nvwvpfh/TtGudO8UWOtSX8TSTx2gx9mICEA5bdzuP3lU/KcgHIHL0VYhv7y3s7mzhu547W62/aIUk\nISXacruUcNg8jPStzwl4vm8Gvd3mn6faSatKgjtr24UubRSrByidN5yvzHOApGCGNex/Cr4V3l5o\n+q634lu5/wDiotP8uMwXZ84xytvZ5Gx95tsZHzEEMwcHJFeafEnxnY67cWmh+Go5LTwtpSeXaW4+\nVZXyczEYzk543EnqTguwrg6KkE8y2726yyCB3V3jDHazKCFJHQkBmAPbcfWo6KKK3PDPhLV/Ft6b\nfTIY9iPGs1xPII4ofMcIm5j3LHAUZY4OAcV3njf4I3HhTQ7jULDWf7Ymtdkl1ax2ojeCBt/74jzG\nO3KEdOzHoprg9f8ACGueGLewuNWtI4YNQQvayR3EUyyqApJBjZhjDqc988Vh16ZfeNF8LfDfQvDv\nhHVpEuL1G1DVry3LRyLKW2iIHdlCuzDYA3BUI4cg+Z17h8MfHl/peh6zdN4cgg8PaXFLew/YzJAj\nXX7uPymmdyHyHLbXLt93aDtRR4/rWsXGvamb+6SBJjFFEVgiEaYjjWNcKOF4QcDA9ABxWfRRRRRR\nRRXSeBvCM3jfxLHosE0kDuhczCAyJGoI3F8EbRtzg92KLxu3D2/xdLpHhv4TappPgHW5LOTRntJ7\nyW1z5lws+3axmGAS4KvuQnhQvCnA+cJ55rq4luLiWSaeVy8kkjFmdickknkknnNR0V6pa2/wr8Oa\nXoqa3Hd6/eTpJc3Uun3GAn8McZQMoCEFn5ZZQVXcqhig4u20G48XeLbyy8I6XPLDJLLLbW7MAYoA\nxK72ZsDAKjJbqQMkkZPE/gnxF4O+y/2/p/2P7Vv8n99HJu243fcY4xuXr61n6FZ3GoeIdMsrMwC6\nuLuKKE3CB4w7OAu9SCCuSMgg5HY17f8AG7x1caTeDw7aGA6hNp6pqN5bsFDhw6mNo+WGFZioZ2AE\nxO0tsdfAKKKK2PFPhu88I+I7vQ7+SCS6tdm94GJQ7kVxgkA9GHaseti+ufDclnIthpWqwXRxskn1\nOOVF5GcqIFJ4z/EPXnpWPVizv7zT5TLZXc9tIduXhkKE7WDryPRlVh6FQeor1C5+MlvfN4pW70G+\na38QeWJIYdXMYtwkSx5TEX3m25YnhgFUggHPm+sal/aV4jRyXxtYIkgto726+0PDGo4QNtUbQc4A\nUAZx7nPorU0Dw5q/inVF03RbGS7uyhfYpChVHUszEBR0GSRyQOpFaFt4h8V+ELLVPDiz3enQXqFL\nyxuIADh0wfldcoSrDkYJG30Fc3UkBhW4ia4jkkgDgyJG4RmXPIDEEA474OPQ1HXSa/4g0jV/D+iW\nNpoUljeaZbi3a6F6ZFnUlnYmMr8pMjuww3G4jkbcc3WpoGiN4g1RbFdQ03TxsLtcajdLBEoHueSS\ncAAAnnPQEiPW9K/sTWJ9O+32N/5O3/SbCbzYXyob5WwM4zg+4NZ9FFbmheL9c8NXEdxpF3HbSRpt\nUi3ibu3zEMpBcCR1Dn5grFQdpxWhZeOJrH4Zaj4MisYyl/ei6lumkOQoEfyKuOu6NTuJPBIx3FfW\nvEmm3vh+y0TS/D1pYwWz+Y15KVlvZmy5w8yogKYcALt/gHNZ+k+HNX1231C402xkng063a5u5AQq\nxRgEkkkgZwCQo5ODgHBrLorY8LeJLzwj4jtNcsI4JLq137EnUlDuRkOQCD0Y96ueJfH3ijxfbwW+\nu6tJdQQOXjjEaRruIxkhFAJxkAnOMnHU1zdaGoa3qOq2dha31x58enxGC2Lou9I85CF8bmUdgSQu\ncDArPooooooooqxYfY/7Rtv7R8/7D5qfaPs+PM8vI3bM8bsZxnjNdJ49PgtdUtbfwVHdtaQW6pPd\nTu2LmT+8FYAqex6AnooAy3J11HgWbwdFrg/4TO1vp7E4CG2kwik8EyKMOVAO7KNkbcYbPFg+J7WC\nXXZPDHhn7BZ32ni2uUe7nnNtGWUMyupTCs3l5D7gTx91ip5e+v7zU7yS8v7ue7upMb5p5DI7YAAy\nx5OAAPwqvRRRRRRRRXcaXq3gbw1rGoM+iT+J4Ypbf7BJdSm2Rtit5rsozlWfbtRlPy8NzkH0f/hp\nr/qUf/Kl/wDaq8Aor2T4bRr4O+H2u+J/EU0f9g63bvY2+nANuvpVEmAXQExDiVAf9ok4wufG6Kkh\ngmuXKQRSSuEZyqKWIVVLMeOwUEk9gCasalpOpaNcLb6pp93YzsgdY7qFomK5IyAwBxkEZ9jVOrmk\n3kOnazY3txaR3kFvcRyyW0mNsyqwJQ5BGCBjoevQ13niv4l2WvXmrQSeE9Dlt7nzFS9HmPd78HbI\ntw21tofBClF+QBMAV5vXSeCvBWpePNZm0vS57SGeK3a4Zrp2VSoZVwNqsc5cdvWrniT4daj4bguZ\nTq2h6l9jz9sj0+/WSS1w6x/PG21vvuF4BweuK4+iiiiiiiivbPDX2n/hm3VLPQrXUrzUNQ1MwSpY\nI8rRn92W3AKCqGJApwXB3jJ+YquG+s/B258l38M65ZZtJI5obeTzNszbNrpI83OzDgZXDbskcYro\nNZ+E/hq58M3XiOyvJ9Nmu9E/tjT9LQNKkKRxRtMrSMSXyXUA5XG7OGAwPD60ND01NY1yy0+W8gso\nZ5VSS6nkVEhT+JyWZRwMnGRnoOSKz6KsWtheX3n/AGO0nuPIiaebyYy/lxr952x0UZGSeBVeipII\nJrq4it7eKSaeVwkccalmdicAADkknjFdQfhz4jj1nT9KuLaO2ubuy/tCT7Q+xbO33MDJOxGIwAuT\n3GQPvHbVzxx4D07wXp2nH/hJ4NR1O8iiuPstvbN5fkuG/eJNkq67lwOASDnArh67T4YeDJvGfjG1\nt3sJLnS7dxJfsJTEqR84BcAnJIwFHJwcFcFlPG/jfWtWvb3RVvo4dDtriSK3sbCctahA/AVuDIgK\ngrnhRjYqLhRx8EE11cRW9vFJNPK4SOONSzOxOAABySTxitzR/Beu654tfwzaWn/EyileK4DMCkGx\ntrs7DICg9xnPAGSQD0mj+CPFHh34pab4YuGktp75wJTazoy3FnvPmEhsqyFY3Ox15wAVOcVn/FXx\nA3iP4g6jdPa3do9u5tGt7m4WXyzGSuF2jCA4yVBYbixDHNcXRRRXrnwp+LOi+BdLn07UNBkJlcyP\nfWRDSzHjarq5AwAWwQwA/u5LMfL9W1KbWdZvtUuFjWe9uJLiRYwQoZ2LEDJJxk+pqnRXceEfhlqn\njDwlreu2Um3+z+IIBHvN24Xc6LtO4MFK4+U7iwGRyRw9FeieHvhBqvirwnD4g0rVdNaDZJ9ogfzD\nLC6MwKbI0csSoRgOCd4AHQnzuiius0D4leLfC2lrpui6nHaWgcvsWzgYsx6lmZCWPQZJPAA6AVzd\nhdfYdRtrz7PBceRKkvk3Cb45NpB2uvdTjBHcVuaN451rRtU1PU/Njv7zUbJ7GeXUQbglG28/McMQ\nEUANkY4IIqn4k8U6z4u1GO/1y8+13UcQhV/KSPCAkgYQAdWP51j0UV3GnfEy80TwvqPhzSdG0qGx\nvopreS4kiLXbxuXx5kqlQ7KHIBKge1cfYTW9vqNtNeWv2u1jlR5rfzDH5qAgsm4crkZGR0zXQeMf\nFtn4p/s77H4a0rRPs0RE32CEJ58jY3McAYXgbVOSMn5jnjtPgJp98viXU9ag0WS+Frpk4tHZdqNc\n5jxGspG1HKsRnqAx7Zqn4m8E/FvXtRM2uaffXk1z5eQk0TR/IQiZWNti4MpPQcNI3Tea6jWPEnhP\n4b6Zovhi78J2PibULO0Iubu5VNiOZHLpHI0RLqJDKOANuMElgwHi+s6ZFpGovZxapY6lsyGmsS7R\nhgSCAzqu7pnK5UgjBNdp4Y+Jy+CPDD2Ph3SY49WvLdlvdRmkZsyiRvKZEJK4WNiOgyzAkEL8/ndd\nx8O9Q0Lw7/a3ibVTBPqGnxKuk2MsZfzLp922TAYfKmzknpuBBDBc6nwe1uxi8a30esalqUN5rtu+\nnRXUAy4lmYHzDJncr7lUA7W5bJIA5uWnxGt4Pi5ca3q1h9it9OtLix0uA2xQ6eEVxErQqRublkKF\ngAZD8yhRjy+/vrjU9Rub+8k8y6upXmmfaBudiSxwOBkk9K6TwP4Qh8TXF5e6pqEeneH9LRZdSvGY\nblViQqIvJLsQQOD9CcK2Pr9lpGn6o1vouryataKgP2prQ24Zj1CqzE4HAycc54xgnPggmuriK3t4\npJp5XCRxxqWZ2JwAAOSSeMVqaz4V13w9Z2N1rGmT2Md95n2cTgK7bCA2UPzL1H3gM5yMiseiiivT\nPgdaNceNb2eLTrTUZ7LTJbqC2uEUmSVGTywjscRPuK/OQcDPHOR5/q2pTazrN9qlwsaz3txJcSLG\nCFDOxYgZJOMn1NGlac2rapb2CXNpbGZ9vn3c6wxRjqWZ24AA/E9ACSBWh4t8Or4V8QS6ONUtNQlg\nRRPJa7tscuPnjJI5KtkZHtnByoI/GGvxeE5vC66lIdFlfe1qyKwB3B/lYjco3KDgEDOfU5w6KKK2\nNR8SXmp+HNF0OaOBbXSPP+zuikO3muHbcScHBHGAPxrHooqxew28E6pa3X2mMxRuX8sph2RS6YP9\n1iy577cjg1XroPD+raFp+j6/baton9oXd5aCKwn80r9lk3Z3Y/I5HPybfuuxHP0UUUVoaHo9x4g1\nyy0i0eCO4vJVijaeURoCfUn+QyT0AJIBk8Q6HN4c1ubS57q0unjSNxPaSF4pFdFkUqxAyNrDnFZd\nFFFFFFFFFWLqwvLHyPtlpPb+fEs8PnRlPMjb7rrnqpwcEcGq9bGi+JtR8P2erW1gYFXVLQ2c7vCr\nOIyRuCsRlcjIPY5zjIUjHrQ1PQtY0Tyv7W0q+sPOz5f2u3eLfjGcbgM4yOnqK6zwLH8PrfRtU1Hx\ndNJd6giOtlpIE0ayEKGDGWMcFm+UZIC4JIORjg6KK9Y8L3XgbQPg9qWo31vpWseI7yVoEsrtD5kO\nflUD+IKFLSb025JC7gwGOH8O+DtU8T6drV/Y+Qlro9o11dPM+OAGIVQASWIRsduOSOMx6+PCq29g\nvhyTWZJwhF6+opEis2FwY1QkgZ35BJxxyeaw6KKkAh+zuzSSCcOoRAgKlcHcS2cgg7cDBzk8jHMd\nFFaH9hax/Y/9r/2Vff2Z/wA/v2d/J+9t+/jb97jr14rPor0DxRHonhTwpL4RgMGoa613Ddz6olnE\nY/IeBHEcMxYuV3FSGAXIJ4wTnz+iitjRtNfVbO+tbDSb7UtWPlmFbaFpBFECfMchOd2fLUZBXDPk\nZ2keqWfwr8ERa3B4Qv8AXNSuPGBt3eSG3IitRKEEix72iYgFTndzwrEgEhTw/iP4WeLfDVheape6\nVJHpdu4H2iSaDdtLhVJRJGIJJHAJxnqetcXRRRRRVi6v7y+8j7Zdz3HkRLBD50hfy41+6i56KMnA\nHAqvRViwvrjTNRtr+zk8u6tZUmhfaDtdSCpweDggdauav4k1rxAlomsapd3wtEZIftEpcqGbceTy\nST3POAo6KAPQPg3o+p2d1qXjdVjj0vSbK6LTNBHOWlWIHYqF1YHDBtwK5AK7huNeb6rql3rWqXGp\nX7xvd3L75XSJIwzdztQAZPUnHJyTyTVOiirEN/eW9nc2cN3PHa3W37RCkhCS7TldyjhsHkZ6VXoo\noorvPBnwp1rxfpb6y1xaaXosT/vL29YqCi58x0GMEKAcklRnjPBxxd/a/YdRubP7RBceRK8XnW77\n45NpI3I3dTjIPcVXr1zxhFq+k/APwVZy+XHaXDzSTRNAJC29zLC6ybSEOwtwGViHIwQGx5HRRRXQ\neDvB2qeONc/snSfIWZYmmkknfakaDAycAk8lRwD19MkZ+uaS+g65e6TLcwXE1nK0MkkG7ZvXhgNy\nqeDkdO3GRg13Hwo8U6N4Fl1fxHf3nm332RrW10uOJ985ZkbcZMbEUFQOpP3jjgBub1bxdNP43vvE\n+hwyaNPdPI4WOcyNG0iFZSHIByxZzkAbd3GMCtjwhPN498T2uh+MPFGstpZSWcmS7LqjRxs24mRi\nqAKGO7B9OMkjg6KKKKKKKK0NP0LWNXx/ZulX17ndj7NbvJnbt3fdB6b0z6bl9RWx4L8Aa748vJ4N\nHjgEdvt+0TzyhEi3BiuQMsc7CPlB98Dmq/im7xLZaKNL/sxtHiNpcwC480SXQYiaYnpuYhQcZ4RQ\nDgADn6KKKKK2NT8QPquj6bYXGn2KSafEIIruFGSRogzttYBvLPLkltm4nkknOceiiuw1jx19s8Da\nX4U0nTv7KsYP3l/5U+/+0JsL+8f5QRyCdpJH3R/AuOfutC1ix06DUbzSr63sZ9vk3M1u6RybhuXa\nxGDkAkY6is+vVNI+PnjDT0u2v549TndFW3E8cccUR3ZZmWNFZyQMD51AySQ3GPP/ABHr994p8QXm\ntak0Zu7pwz+Wu1VAAVVA9AoA5yeOSTzRrepWOpPYvY6VHp5gsobe42SbhcSou0zYwApYAZA7gkkk\nk1nwQTXVxFb28Uk08rhI441LM7E4AAHJJPGKsarpd3ouqXGm36Rpd2z7JUSVJArdxuQkZHQjPByD\nyDVzRtb13wdrCX+mXE+n33lDBKD5o3UMMqwIZSCrDII+6R2NZc8zXNxLO4jDyOXYRxqigk54VQAo\n9gAB2qOiiipBCzW7zgx7EdUIMihssCRhc5I+U5IGBxnGRmOiivZPBXwNh8ZeCNO11dfks57p5i8Z\ntRIoVXKKB86nOUYk99wGBjJ8boorqLP4ieKtP8Lt4atdV8vSGikhNv8AZ4jlJCxcbiu7nc3fjPFd\nJ8PPEM3hr4b+Pr20uY4LyRLK3t2ZyrbnaVSUwQd4Uuwx0256A1x/g/w1N4w8WWGgwXEdu927AzOC\nQiqpdjgdTtU4HGTjkdaj8V6ZZ6L4t1bSrCaea1s7uS3R51CudrFTnBwcEEZ4z1wucDHoorrPBPw/\n1fxtfwJa+XbWD3AgkvZmAVW2M5VFJBkcKpO1enBO0HNc/q1nDp2s31lb3cd5Bb3EkUdzHjbMqsQH\nGCRggZ6nr1NU6KKKuaTHDLrNjHcCNoHuI1kEhAUqWGckugAx/tp/vL1Htn7Q3iG4sZdK8H2C/ZNM\nW0W4lihIVJBuKxptA4VPLJAzg5HHyg14PRRRXonw+gsfD2kX3jm91yOxvLdLmz0e3VN7zXfkH5mG\n0jYokX2yw3EDAbh9M1KbSb2O9tVjF3C6SW8zAkwyK6uHUZwT8uMMCME8ZwRoeLfFFz4x8QS61e2l\npb3cyKsv2UOFcqNoYhmbB2gDjA4HGck4dFdQ3gHW5PD2ma3p8X9pWuoStBGlnFKZFlCFyuxkBbAV\n/mTcuUYZ4rm54JrW4lt7iKSGeJykkcilWRgcEEHkEHjFR0Vc0oaa2qW41iS7TT9+ZzaIrS7fRQxA\nyemT0znBxg7HiiTwabeyi8Jw6yHV5WupdUMe5gQmxV8s4wMOegPzdTxjDurKWz8jzXgbzolmXyZ0\nlwp6BthO1uOVbDDuBXoE/itL/wCFWheH/EFt9ntLbVYpYHs1VJri0AlWVgmNu5WbAc4DsT1ZHNc/\n4gTwONDsZPDr65/a0u17mK9aJ4YR8wZAyqpZshSDjBU84OQOXruP+EE0u3+H/wDwk174usUupYvN\ntdLgj3TSjd5fIdkIw4cMQrABCQW6Vw9SEQ/Z0ZZJDOXYOhQBQuBtIbOSSd2RgYwOTnjpPAfjJ/BG\nuT34svtkNzaSWk8SztA+xsHKSLyjAqvI98YOCOs+FnhjQ/ECeIvFPjl5JdJskHmTXDyqJZnbczeY\nrAs4wBt5LGVe+M+Z381vcajczWdr9ktZJXeG38wyeUhJKpuPLYGBk9cVXoruPhprFvZ68INT1++0\nqziinurSWKQmGC7ERCyvHkb/AJdw2jlztQ5ViDxc4hW4lW3kkkgDkRvIgRmXPBKgkA47ZOPU1HRR\nRRXtnji10zT/ABv4I8O+NUtINJ0zR4luby08xpJwEK7WITds8yPAAGQHY5BbC+V+IbyCS8FjZXUF\n5YWX7q3u002KzeZcAbmCjc3TguS3c4JIrHooqSSeaZIUllkdIU2RKzEhF3FsL6DczHA7knvUdSCN\nTbvKZow6uqiIhtzAg5YcYwMAHJB+YYB5xHRVxdW1JUskXULsJYOXs1EzYt2LBiY+fkJYA5GORmq8\n8811cS3FxLJNPK5eSSRizOxOSSTySTzmo6KK3PEHhDXPCyWz6xaRwJcvKkTJcRShmiYLIPkZsFWO\nCD3yOxrDrvPGvi208R+A/BFks0Z1DSree3uoUjdRGoMaRHJ4JKRgnBPOenSuDoqxYXX2HUba8+zw\nXHkSpL5Nwm+OTaQdrr3U4wR3FWNd1D+1/EOp6lnP2y7luM+X5ed7lvu7m29em5sep61n0V6RrcN5\nafB7wdolvpE8U2r6hcXrhkLSXUi7UiaNQx+VklAxtBJUEDBy3n81heW/2jz7SeL7NKIJ98ZXypDu\nwjZ+63yNweflPoar0UUVc0zSr7Wb2Oz0+2kuJ3dECr0Bd1RdxPCgs6rkkDLD1rY8beHYfCutwaSp\nkF3HZW730byhzHcOgZ1yFAAG4YwXGMHdkkDm67D4leN/+E98Wtqsdr9mtYohbWyMcuY1ZmDPzjcS\nxOBwOBzjJ4+tCW/1HWPsOnzXe6GHENrDJIsUMOcAkZwiZIBZjjJyzEnJqx4h8L6t4VvBZ6xDBBdH\nrCl3FK6cA/MqMSuQwI3Yz2zWPRRRRRRRRRRRRVixsLzU7yOzsLSe7upM7IYIzI7YBJwo5OACfwqS\n80nUtPt7W4vdPu7aC7TfbSTQsizLgHKEjDDDA5HqPWo7GwvNTvI7OwtJ7u6kzshgjMjtgEnCjk4A\nJ/Ci+sLzTLySzv7Se0uo8b4Z4zG65AIyp5GQQfxqvRWx4V8PXHivxRp2h2rbJLuUIXwD5aAZd8Ej\nO1QxxnnGBzVfXdM/sTxDqek+d532G7ltvN27d+xyu7GTjOM4yaz6KKKKsWE1vb6jbTXlr9rtY5Ue\na38wx+agILJuHK5GRkdM1ueOfEOm+JfEsl5o+i2mkaeiCKC3t4VjLKCTvcLxvOe3QADJxk83Wppu\njLqGl6lfvqum2YsUVvIupWWW4LZAWJFUljkc9AMgkgZIy6kggmuriK3t4pJp5XCRxxqWZ2JwAAOS\nSeMUTwTWtxLb3EUkM8TlJI5FKsjA4IIPIIPGKJJ5pkhSWWR0hTZErMSEXcWwvoNzMcDuSe9aGg6F\nc+Ib+S1t3jhSG3lup7iVXMcEUaFmd9isQOMDg5JA71nyRqiQss0chdNzKobMZ3EbWyAM4APGRhhz\nnIHYaF8KfGHiEx/Y9NjRGfbIZ7mONoB5jRlpIy3mKA0cg+7k7GwDij4k+D9I8FeIG0vTtck1CdXY\nz28lsY2tVIVowX+7ISrdVA6dBnA4uiiiiiiiiiug8KeDtU8YXlxFYeRBb2sRmur27fy4LdACcu+D\njODjjsT0BI6jxRY3/iP4f6br1rH4UTTdHiWF7fSGkW5tkkbAE6ycnDhscnJdmG4EtXm9SGNRbpKJ\noy7OymIBtygAYY8YwckDBJ+U5A4zHRXqHh2bVPg9Z6V4ruLWC4uNeiAtrYyZH2TKvIWI+7I37goR\nuABfcM4FY/xK0nTtJutEFn4an8PXF3p4uriylvGn2bpXVPvDcrbUBIJ/iA2gqc8PRRRRRRRRRXqj\nwaD8IPEuhy3umya5r0Vl9ovbaW5RIrK4cqYwu0N86KHzuyDuR1xxjP8AGfxVbxp4aSwuvDum22pG\n486fUIEUmQYAwoZSyEhIgWD5IjA6HA87qxa395Y+f9ju57fz4mgm8mQp5kbfeRsdVOBkHg1XqSGe\na2cvBLJE5RkLIxUlWUqw47FSQR3BIojhaVJnUxgRJvbdIqkjcF+UE5Y5YcDJxk9ASI6K9Y03wX4J\n8VaHpd8dW/4RjVtSu0toNPUyXaSH7m5EYK6q0it8xd0XBUtnIXj/ABn4W07wpdRWdr4hg1W7824j\nuYoYGT7P5cpRdxJ+821iV7Y4LKVY8vRRRRRXSeDvFEPhe41ZriwkvYNS0ybTpEjuBCyLIVywYowy\nAvp3qPxXZeH7SXSpfDl1PPb3Wnxz3CTyrI9vOWcPESET7u0dRznI4Irn6KKKuWmq31le2F5BcyCf\nT3V7Rm+cQlXLjaDkY3EtjGMk+po1XVb7XNUuNT1O5kuby4ffLK/Vj/IADAAHAAAGAK3PAEvhq18U\nJfeK23abZxPOLXyGl+1ygfJFgHAyTu+b5TtweDXeWFv4N1nwd4n8R6zo8dhpMt7byWlnozxzXtk5\nyrlm2jy4nYHCyYXg7VBKFuT8f+BLPwhFZXVtrcFzHqP7+1s2IadLdlUq7shMZ5LLlThtoK5BYJw9\nFFeifDqDTbPwn428SXkUkl3ptlFDYsiqTBNOzKky55V0dUIZSCBuxk4rj9N0DUtQt2v003UpNLhc\ni6vLW0aZYVABck8LkKc4LDtkjrWfPBNa3EtvcRSQzxOUkjkUqyMDggg8gg8YqOiiiivVJ/gF4qj0\naXVLfUNGvoFtzcRrZzSytOu3cBHiPDFh055yK8roq5pWlX2uapb6ZpltJc3lw+yKJOrH+QAGSSeA\nAScAVY1/w5q/hbVG03WrGS0uwgfYxDBlPQqykhh1GQTyCOoNXPBfiGz8K+KLXWrzSv7T+y5eGAzC\nNRJjCsSUbO3kjGCGCnPGDJ4o8Vw+JreyVfDujaTPbPKXfS7YQLMrBNoZeTlSrc5/i6DHPN0UUUUU\nUUV6B8I9M0e48UXGr+IZrFdG0i0e5uY7xUkWXcPLVfLJy3L5yFb5go6stef0UVuah4P1/S7fR57v\nTZAmsoH08RusjXAIUjCqSQTvTggHmsu+sLzTLySzv7Se0uo8b4Z4zG65AIyp5GQQfxqTSdSm0bWb\nHVLdY2nsriO4jWQEqWRgwBwQcZHqKk1vW9R8R6xPq2rXH2i+n2+ZLsVN21Qo4UADgAcCjQ72z03X\nLK+v7D7fa28qyvaFwgm28hWJVhtJxkYORkcZyOw8e/EPR/GWnCKz8G2OkXzXf2ma+hdGkl4bcrER\nqTksGJJPIri9LsF1K/W1e+tLFCju1xdsyxqFQtztBJJ24AAJJIA61TruPh38TdU+H15KIo/tumT5\nM1i8mwF8YDq2DtbgA8HI4I4Uiv46+I+s+PLwm/EEVjHKZLW2SJCbcEYwJNu85ABPOCRnAwAOPooo\norQsL7VPDesW1/ZyT2N/BsmhfbtYBlBU4PVWVh14ZW7g1n0V1HgDxpceA/FCaxBB9pjMTwz2+8J5\nqMMgbirbcMFbgfw46E1J42+IetePXtW1hLRRavI0K28ZUIHVAV5JJGY885OWbnGAOToqxb3X2eC7\ni+zwS/aYhFvlTc0WHV9yH+Fvk25/usw71XoooorUvdSsbjw/pen2+lR293avO91eiTc10XK7cjHy\nhFXAGSOSeCTnLqxfWUun3klrM8DyJjJgnSZDkA8OhKnr2PHTrWp4W16Hw/f3c1xb3dxBdWU9nJDb\nXYg3LKhQ7iUcMADkDH3gp7YMngfVtL0HxpperazbT3FjZy+c0cH396gmMj5l6PtPJ7d+lY9/cJd6\njc3MUXlRyyvIseFGwEkgfIqrx/sqo9ABxXeeF/g34j8Q6Wms3clpo+jlFmN1fSbSYed0iqOwUbvn\nKgggg4ORufEDxBZ+DvFulXvgvWrG/kh0SKwjuPMF49r5bbd6kgxozINuF/vSEqC4J871zxDr/jjW\nbafVJ5NQ1AotrCI4FVmG4lUCooydzHtnmtRPAWo6NZ2uteL7K+0vQpJRGxVF+0ytk/u0jYgqxCsd\nz4UBSfmO1W0NO028+Ieg2Nnaw6Holj4atPLudSvLgxLI0spK73O48ncQv3QxfBG5VHn9FfQeqfBH\nwD4eGlR634tu7KW5cozTSxRrOVjJbZlf3Y3bTliwHC9WU14Jf/Y/7Ruf7O8/7D5r/Z/tGPM8vJ27\n8cbsYzjjNV6sWtheX3n/AGO0nuPIiaebyYy/lxr952x0UZGSeBXcfC3T/Dr3Ws634mFjNY6TaJLH\nbXUkg3zNKqoxVFYtGD8rfKwHmLlTmvP6KK9E+DPh6HWfG4vdRtrSXRdLt5bi/a9QNAFKMqhtwK5y\nd3zY4Rj2rrPEGtaj48+A0usvNY2NvpF2LeXTrbTVWNvmhWLy3Z2ZNqueV25DFcYGW5u7+E0N14OO\nveFvEUevzokMk2m29sPtESydAyxvIQ4PVTjhW5+XB8zooooor3TxBq994m/Zy0+70u/jtrPSki0/\nVrFo9xmKNEsZVyuQQfLfA4xIQSSuD4XXcePPA2neCooLaTxBBca7+7+06ZCjSCFSpy/nYUckAhCo\nYBx94Dc3D0UUUUUUV6B4x+Jeo+LvDllb3OrXy3Riji1CzSBUtp2jeQrKGD53EMmV2BSVz/CoHn9e\nmfA+Oxh+INndanNJZ+YjxadcEYV7kGPdECQVJaN2Ug8/vBjDFDWf8TPiZN8RbjTmbS49PgsUkCIJ\njKzM5XcS2FGMIuBj15OeK+m+OIbD4Taz4Naxkee/vY7hLkSAKqjYWBGM5zEoHrvPTbhuLq5pMdjN\nrNjFqk0kGnvcRrdSxjLJEWG9hweQuT0P0NdZ8WPGNv428czX9jzYW8S2tq5Qo0iKSSxBPdmbHT5d\nuQDmuHqSCCa6uIre3ikmnlcJHHGpZnYnAAA5JJ4xXrGq2Nz8KPB2s+GtV1yS51DWkTZp2nTOkUMR\n3ZnLtHyS0fltGNu5Cck8bYz/AGt4e/Z/tJtO8ibTNdlm/tEXnlN5EiyhI/IU4Ysyx5PDldm5dmM1\n5PXQeE7Hw1d6xbjxTq89lpr+YJDaRM8iEKCpJ2kBWJIyA5ypBCghqz9b/sf+2J/7A+3f2Z8vk/b9\nnnfdG7ds+X727GO2K6DwH4p0Lw3LqUWu+Hv7XtdSiS1lInKGKHdufauMM2QjA5UgoMMM5rqPGXxS\n0yfQ7TR/A66rpVgtpJZT2cyQiAwv975fnZpG7uWBGDjl2NSfDzXdI8C/D7U/E8N7HeeIpLjyotNG\noGJY1A2q8kOVMoBdjwH/AIcFCHK+R0UUV1nw8j8Hv4lZvG00kelpbuyKokxJLlQFbywWxgseMcqO\nex9I1TxJY/Fmy1PSvtMfhvwloSQ3sFy+m7igVDH5blZdqkl22IqksBgcjB4Pxj8QP7a0fTvDmh28\n+meHtOiMKwmb57v5gRJMqYQsSobGDhixyc8R+AfhtqXxCTVTp15aW72CRHFxuxIzscDKg4G1XOee\nQoxySOTvb641CdZrqTzJFijhB2gYSNFjQceiqo98c81XoroPBnh6z8UeI49JvdV/suOSKWQXTQiR\nE8tC7b8uu1dqsd2T0HGDkYc8LW1xLA5jLxuUYxyK6kg44ZSQw9wSD2qOiiipBIot3iMMZdnVhKS2\n5QAcqOcYOQTkE/KMEc5jooooooorQ0nWbzRJZ57B/JupYvKS5QlZYPmVi0bAgqxClSf7rsO9R6lq\n2pazcLcapqF3fTqgRZLqZpWC5JwCxJxkk49zQdVvm0ZNHNzJ/Z6XDXQtxwvmsoUufU7VAGenOMZO\ne4+D1lpD+Jb7VfEVjaT6Hptk8tzNeAmKFiQqfLtIdzkhUPXkjLKAcfx94j0XxHrMc2haFaaXaQoy\nAw24gaYFiRvjVmQFQQuRy2CTgEKnJ0UVqDw3rTeH314aXd/2SjqhvDERHliVGD3G5SpI4BwDgkA5\ndFFFFdhpfifR9N+HGuaAlnff2nq/k+bO0qNCPJmV02rgMMq0gOSeVXH3jt4+vTPgv4rudG8SyaDF\npsl7Br7xW0pgleKWAAkGRWTkBVd2OMEYB3Lg15nRRXYeBPFdh4N/tfUzbTza61oYNKkVYzHbu+Q8\nrbgSGAxjAOQWU8HI5ewsbjU9RtrCzj8y6upUhhTcBudiAoyeBkkdak1XSr7Q9UuNM1O2ktry3fZL\nE/VT/IgjBBHBBBGQap13ni/4U614J8K2OtatcWm+5uBA9rExZoiyb1y2ME/K4OOBgYLZ4pw/DvVJ\nPANz4qkmgiWOVUisiczyoU8xnCjphCJAD1jDPwoBbj6kIh+zoyySGcuwdCgChcDaQ2ckk7sjAxgc\nnPEdFFFFFWHtvKs1lmWeOSXD24MWEljy6swYnsy7RgEH5uQVwa9FFFSQCFriJbiSSOAuBI8aB2Vc\n8kKSATjtkZ9RXeXHxE0drzQ3tfAeh29rp0shntmiSQXkZG1Fd2TduVCfmJYM+HK8AVzfi3XLHxF4\ngl1HTtCtNFt3RVFpanKggYLHgDJ/2VUdOCck4dFFFFd5H8GfHszzJFokbvC+yVVv7YlG2hsN+84O\n1lOD2IPeuX1vw5q/h248nVbGS3Jd0V8h43ZDhwrqSrFScMATtPBwRisurH264/s77AZM2ol85UZQ\ndr4wSpPK5GM4xu2rnO1cV6KKKKKK3PCPhe+8Y+JbTR7COQmVwZpVTcIIsjdI3IGAD0yMnAHJFe/y\nXlzpXwh8NyXWgyeLtS1F4rtrfUZXvSwZdzFC6H5/LOBGoyoLt84SRj4p4u8beOdX3aR4n1C+j8rH\nmWUkIts52sPMRVXd0UjcDjqOtcfRRXSeBdCsfEPidLXVnu4dJht57q+uLVctBFHGzbz8rYG4KOhz\nkAckVY+Ius6VrnixrnQ9KtNM01beJYIbeKOMsCu8s4jZl35cjrkAAEAgiuTqSCFrm4igQxh5HCKZ\nJFRQSccsxAUe5IA716o3w68Ha5rGmeHPB3iG+1LV2lYajdtDm0gijU+ZIMKM5baEwzKc4Lcgnk/i\nD4nh8R+JZl0xI7fQbN2i020gQRxRx5+Z1QKuC7Zc5GeQCTtFHw8j8Hv4lZvG00kelpbuyKokxJLl\nQFbywWxgseMcqOex3PFE3w1sfCUcfhfTZ77Unu5rY3mozOH8tVz5oRJFAyZE2bkwdjblyOfN60ND\n0a88Q65ZaRYJvuruVYkyCQuerNgEhQMknHABNWNY8LazoOuJol/Z7dTfYFtYZUnfL/dXEZb5jxhe\nvIOORWXPBNa3EtvcRSQzxOUkjkUqyMDggg8gg8YqOiiug8L+EbzxV/aTW15Y2sOm2jXlzJdykYjX\nqQqKztgeikDgE5IB7zwT/wAIe/giDSbK10bUfGmr3Agki1pJBHChdlHluFAU7MN8rhiW4LMFQ7Hj\nTwh8NobiLw3aPaaB4gjeF724lvJ3gtlYxgqDIMSkiUEYCcKWZkCkHn/h/wCANV8b3/8AwlvieaOT\nQYnJu7rVLiTdcoiEMVYMDhdoG8sAMfxbWWuf+J3iqx8UeLJG0aGODRbRFgs444vKVwqqpkKdASFV\nQcA7EjBA24ri66CXwP4lt9Dv9ZudInt7GwlWG6acrG8TtsIBjYh+RIh6fxVz9FFFFFFamgeI9X8L\naoupaLfSWl2EKb1AYMp6hlYEMOhwQeQD1Ar1TxDda78KvCXgV9I1udpLm0upZYRMJLbfIqkMqhir\nbfNGOShKBwuWbdy9v4ci1f4da54717U77UbxZY7W3Ecrs6zfdP2hnjb5QpjIIbB+7uDEAef0UV6B\n4JttU8OaHf8Aiu90qeXwzqET6NeSRcTeVNw8sWRt+VlUbm+UswXrkrc+IHwjbwJ4Vs9afV5Lh7m4\nSBrWS0WNoiyM/LLI4JGzHGR6H18zoqSGea2cvBLJE5RkLIxUlWUqw47FSQR3BIqOiiuk8B+FJvGf\njGw0ZBIIHffdSJn93CvLnOCAcfKCRjcyg9a9E+BVr/ZNn4j8WajcQafpEVo1mdRL5mikJRiEQ5U9\nVPzKSW2BQcsK8jnvZl1mW/t767knFwZo7yQlJ2bdkSEhiQ+efvHB7nrVOiiiirmk3kOnazY3txaR\n3kFvcRyyW0mNsyqwJQ5BGCBjoevQ1Y1fX77xBql7qmsNHeX92iq07LsKldoDKE2rnam3kEYJ4zgj\nQ8Q+Oda8S6NpGj3kscen6VbpBBbwgqrFF2iR8k7n28Z6DnAGTnm69g+FPibwj4V8G67qd0bEeLIP\nNlsTcwu7FRGqxqhxxl3YEKQxXJPyrkeRzzzXVxLcXEsk08rl5JJGLM7E5JJPJJPOajoooooooqQz\nzNbpbtLIYEdnSMsdqswAYgdASFUE99o9K6ifxxM/w3t/BtvYx20CXAuJ7mKQq1y26QkSADDDDQgZ\n6eSOuQF5/TZNNiuGbVLS7uYNhCpa3KwMGyOSzRuCMZ4x3HPHNecwtcStbxyRwFyY0kcOyrngFgAC\ncd8DPoKjrQ/t3WP7H/sj+1b7+zP+fL7Q/k/e3fczt+9z06813Hi74qReIPA1p4U0zRZ9JsbeVGGd\nTe43RqGxGdyglQSpAJIGxQBwMeb0UUUVJNPNcuHnlklcIqBnYsQqqFUc9goAA7AAV1ng74iX/gaX\nztI0rSjcPE0U088UjvKCwYZO8bcYxhNoP8QYhSLHiX4j3GseF7Pwvpll/ZehW0UKG3Eod5HjLkuz\nKqA7yyswKn5kDDBJzw9FFFbiWcPiS/0zTfDmiXaalMixSR/ahKs0gRQXUFQYwSHdsswGeqhap67p\nn9ieIdT0nzvO+w3ctt5u3bv2OV3YycZxnGTWxqfjR77wNpvhS30mxsrO0lFzLLCGMlxOA6+YxJ7q\nwBHPK8ELhRy9SQGFbiJriOSSAODIkbhGZc8gMQQDjvg49DWx4i1XQ9TeI6L4bj0VEdiQt5LcGRSq\nYDF+4YOcjGQ4GPlycOiiu48ZfCnxJ4JitJb1YLyO58zD2AkkEexd7byUGPlDN9EY9BXD0UUUVsaD\n4V13xP8AbP7F0ye9+xxedP5QHyr2HPVjg4UZY4OAcGseiiiiiiipJ41huJYkmjnRHKrLGGCuAfvD\ncAcHryAfUCrmjaHqniHUUsNIsJ726bB2QpnaCQNzHoq5IyxwBnk1Y8Q+F9W8K3gs9Yhgguj1hS7i\nldOAfmVGJXIYEbsZ7ZrQ8A+FE8YeI3sLm5+x2MNpNc3V2WUC3RUOJG3EZUOUyPQnkdR6B8R/E/hr\nQfAln4I8Ez2N3p9zvOoSjc8u+OVNrlxhSzNG2eD8oXaApWvF6KKK1NSs9Ns9L03yLuSfU5kaW8Rd\npigU48pAwJ3Ptyzem5VwGVqy69g+B02hSz6to4ub6y8U6taT2tneoCY4Y9gb5dpBEmQXycDEYAYE\n8+T3/wBs/tG5/tHz/t3mv9o+0Z8zzMndvzzuznOec1XooortPAOvW1vqlnoV/wCGdN1mzv7gwSI8\nCC6Yy7EXy5mIKFSMryoy7ZIJDLsa/wDCTUovEHjEafNpsVhoaG98o3LOwt3EjxoMAkOFTBDkHock\nEMfM69Aj+JtxL8I73wVfxz3UzyxC1uXkGIYFZX2HjJwUAHPR8ZAQA+f1uav4T1Xw+9oms28mnm5t\n2nT7RDIoyF3CPO3BcjZwMhS6hipDBcOitTRfDmr+IXmXS7GSdIELzzEhIoFCs2ZJGIRBhW5YjOK9\nc0bxl4d+HPwqvoPC/iH+0/EV1LGJCY5BFDI4OXSOQLlVVCNwBJbZuGCFHh9dhf6L4Ru/C+lT+HtX\nvpfEcuyO60m4t3dpJGIX9yyJt+9yFJJKkchhtPYaPoPww8PaS+j+OL3zvEbyulw9kZmGnZj4UsmY\n3ZSMHAbDttIIUmuD8Z+DbvwbqiW813aXlpcp51ldW8yMLiE42ybQSVBzjngkNtLAZrm66S28B+I7\nzwdJ4ptdOkl0uN5BI6/eVU25faeWTLEZXONj5xiuboor1D4NwWemawPFGpeJv7FtLe7isdigN9qa\nVXby5OT5cfyA7mXacHDKy5HJ+L9H1KDx1qNo+lalbz3d7I1rbXSs88ivKwTByxkJPG4FtxzgnrXU\nT6LN8PfhleTarZ3dl4k8RP8AZLdTMUMdiBHJISq9CzYRkchsHoAGB8zor2D4xeBtJ8KeHvDt15uP\nEN1uGoHzJZvtkgRTLNvc8Yc9MAt5mf4a8fooq5f6VfaYlm99bSQC9txdW+/gvEWZQ+OoBKnGeowR\nwQTY8N63N4c8S6brMHmF7O4SUokhjMig/Mm4dAy5U8Hgng1X1bUptZ1m+1S4WNZ724kuJFjBChnY\nsQMknGT6mq8EE11cRW9vFJNPK4SOONSzOxOAABySTxitzxp4UuPBXii60S5uYLlosMksLA7kYZUs\nuSUbHVT9RkEE8/RXQeDvFL+Ddc/tq2sYLq+iiZLUzswSJ2wC5VSN3yF1xkfez2rPm1vUbi61S5lu\nN02q7vtrbFHm5lWU8Y+X50U8Y6Y6cVn0VYhuvL+zrJbwTwwymUxumPMztyrMuHKkKON3GSRgkmvW\nP2g7fWf+Eo0y+vpZxpt3aBrO1lKD7K4C+bHhWILZKsW77gASFFeP0V7AmqWHhf4ENH4ZvYLm+1mU\nxatcTJHE8Y8tA8EauQ8m0SoMqHA3SNlcjHj9FeufBW28EWT3niTxNq9pFf6c+62s7khQoC7vNUHm\nV8ggKoJUjOCSpHD6p4qh1b4gt4ouNGtBA96l1JpyAeXIqkEoxIIJYD5mxyWY45xUfjTxZeeNfFF1\nrV4nlebhIYA5dYY1GFUE/iTjALFjgZxXYfHLXNL1Xxbp9pod/Bc6Zp+npCkdo+YIn3MSEx8v3PLB\n2/3QP4cDY1z462dx4SvfDmheE4NOtbq0a3BEoCReYv73bGiAdWfByM8MR1WvF6KK2LfxTrNp4Xu/\nDUF5s0i7lE09v5SHe4KkHcRuH3F6Ht9a6CwsfGPxY1G2sLOPzrXTIkhhTd5dtYQkgKMnk4AHXdIw\nT+LbVf4o6/ceIviLq91cQT23ky/ZUtppRIYRH8hXglRlgzEKSMseT1PH0V7R8ctB8Swz2xTS/L8H\n6LFFaafJEyvsDIgJf5i/3lCZbA+Ve7ZbzPwr4S1fxnqkunaNDHLcRW73DB5Ag2rjjJ7liqj3YZwM\nkV/EmlNofiXUtMa2u7YW9w6JFd7fNVM/Ju2/KSVwcrwc5GQRXefBHwXpfi3xRLcapPBJHpmyb+zp\nU3fagQwz94fKjBCeCDuAPB5Pji2uv4tt/wC2tJ+zRwxG3sr5nDPewo333KnywxJZ9qqpXzACMba8\nvor0T4V2ukaRrdn4w8S6haWek2dw8UCSxGZ7i4CZ+VFBICb0cuRgEoBycjk/Fl9b6n4y1y/s5PMt\nbrULiaF9pG5GkYqcHkZBHWqelXVpZapb3F/p8eoWiPmW1eV4xKvcbkIKnuD6gZBGQes+KuoaXqni\nq0u9L07+z/N0qykuIFOUV2hVlCY42rG0ScBfunjueHooorrPA+teHNEuLyfW7C7e8VFk0y/tTvay\nuFJKuYi6rIMlWwxx8gGCGOMfxHr994p8QXmtak0Zu7pwz+Wu1VAAVVA9AoA5yeOSTzWXRRRX/9k=\n",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import Image\n",
     "fname = save_images(samples, height, width, 10, 10, directory=SAMPLE_DIR)\n",

--- a/statistic.py
+++ b/statistic.py
@@ -17,7 +17,8 @@ class Statistic(object):
 
     self.model_dir = model_dir
     self.saver = tf.train.Saver(variables + [self.t_op], max_to_keep=max_to_keep)
-    self.writer = tf.train.SummaryWriter('./logs/%s' % self.model_dir, self.sess.graph)
+    # self.writer = tf.train.SummaryWriter('./logs/%s' % self.model_dir, self.sess.graph)
+    self.writer = tf.summary.FileWriter('./logs/%s' % self.model_dir, self.sess.graph)
 
     with tf.variable_scope('summary'):
       scalar_summary_tags = ['train_l', 'test_l']
@@ -27,7 +28,7 @@ class Statistic(object):
 
       for tag in scalar_summary_tags:
         self.summary_placeholders[tag] = tf.placeholder('float32', None, name=tag.replace(' ', '_'))
-        self.summary_ops[tag]  = tf.scalar_summary('%s/%s' % (data, tag), self.summary_placeholders[tag])
+        self.summary_ops[tag]  = tf.summary.scalar('%s/%s' % (data, tag), self.summary_placeholders[tag])
 
   def reset(self):
     pass

--- a/utils.py
+++ b/utils.py
@@ -25,16 +25,16 @@ class dotdict(dict):
 
 def mprint(matrix, pivot=0.5):
   for array in matrix:
-    print "".join("#" if i > pivot else " " for i in array)
+    print("".join("#" if i > pivot else " " for i in array))
 
 def show_all_variables():
   total_count = 0
   for idx, op in enumerate(tf.trainable_variables()):
     shape = op.get_shape()
     count = np.prod(shape)
-    print "[%2d] %s %s = %s" % (idx, op.name, shape, count)
+    print("[%2d] %s %s = %s" % (idx, op.name, shape, count))
     total_count += int(count)
-  print "[Total] variable size: %s" % "{:,}".format(total_count)
+  print("[Total] variable size: %s" % "{:,}".format(total_count))
 
 def get_timestamp():
   now = datetime.datetime.now(dateutil.tz.tzlocal())
@@ -43,15 +43,15 @@ def get_timestamp():
 def binarize(images):
   return (np.random.uniform(size=images.shape) < images).astype('float32')
 
-def save_images(images, height, width, n_row, n_col, 
+def save_images(images, height, width, n_row, n_col,
       cmin=0.0, cmax=1.0, directory="./", prefix="sample"):
   images = images.reshape((n_row, n_col, height, width))
   images = images.transpose(1, 2, 0, 3)
   images = images.reshape((height * n_row, width * n_col))
   filename_tmplte = '%s_%s.jpg'
   i = 0
-  while not os.path.exists(os.path.join(directory, filename_tmplte) % (prefix, i)):
-    i += 1
+  while os.path.exists(os.path.join(directory, filename_tmplte % (prefix, i))):
+     i += 1
   filename = filename_tmplte % (prefix, i)
   scipy.misc.toimage(images, cmin=cmin, cmax=cmax) \
       .save(os.path.join(directory, filename))


### PR DESCRIPTION
TF v1.0 changes:
- `tf.zeros_initializer` -> `tf.zeros_initializer()`
- `rnn_cell` moved to `tf.contrib`
- `tf.initialize_all_variables()` -> `tf.global_variables_initializer()`

Python 3 changes:
- `print` -> `print()`
- `xrange()` replaced by `range()` in Python 3
- some changes to TQDM code that uses `trange()`, which relies on xrange

Plus some changes to `save_images` syntax; this had an infinite `while` loop